### PR TITLE
Ignore pnpm lockfile in Prettier checks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 **/node_modules/
 **/.ssr/
 **/*.tsbuildinfo
+pnpm-lock.yaml


### PR DESCRIPTION
## Summary

- exclude the pnpm-generated lockfile from repository-wide Prettier checks
- prevent automated dependency update PRs from failing solely because of lockfile formatting differences

## Validation

- `pnpm exec prettier --check .`