### PR TITLE
Add WebVTT subtitles for the Huabu case video

### DIFF
--- a/apps/docs/landingpage/Huabu-Video.vtt
+++ b/apps/docs/landingpage/Huabu-Video.vtt
@@ -1,0 +1,57 @@
+WEBVTT
+
+00:03.700 --> 00:10.518
+AI can answer a question. But as the work grows,
+what matters gets scattered across chats, tabs, and files.
+
+00:11.500 --> 00:15.680
+Huabu lets you pull an idea out of the conversation,
+and keep it on the surface.
+
+00:18.200 --> 00:23.059
+Bring in links, papers, notes, and questions.
+Their context stays with them.
+
+00:28.900 --> 00:31.591
+A space where you and your agents can think together.
+
+00:34.800 --> 00:41.148
+Now the material can become structure. Select the papers once,
+and an agent can arrange the field as it evolved.
+
+00:47.000 --> 00:54.523
+Ask from the surface, and the work around you becomes context.
+The agent understands the sources you select and answers right where you're working.
+
+00:56.100 --> 01:00.541
+Zoom out to see the whole landscape.
+Dive back in without losing the thread.
+
+01:03.900 --> 01:08.393
+Even a figure or a sentence can move straight from the source
+into the shared space.
+
+01:11.400 --> 01:14.091
+You and your agents organize the surface together.
+
+01:16.300 --> 01:18.991
+When the thinking is ready, turn it into work.
+
+01:22.100 --> 01:30.355
+Set several goals at once. Agents build the page, map the runtime,
+and gather references in parallel, from the same shared context.
+
+01:31.300 --> 01:38.823
+The results stay connected to the question that created them.
+So you can return, ask for a change, and watch the work update in place.
+
+01:48.670 --> 01:51.726
+Act with your agents. On one living surface.
+
+01:54.800 --> 01:59.424
+Collect what matters. Organize it together.
+Act with your agents.
+
+02:00.900 --> 02:05.158
+Huabu. An infinite work surface
+where you and your agents think together.

--- a/apps/docs/landingpage/index.html
+++ b/apps/docs/landingpage/index.html
@@ -334,15 +334,15 @@
       }
       .hero-video::cue {
         font:
-          500 1.7vw/1.05 'Inter',
+          500 clamp(14px, 1.7vw, 20px)/1.05 'Inter',
           sans-serif;
         color: #fff;
-        background: rgba(0, 0, 0, 0.55);
+        background-color: rgba(0, 0, 0, 0.55);
       }
       .hero-video:fullscreen::cue,
       .hero-video:-webkit-full-screen::cue {
         font:
-          500 3.4vh/1.05 'Inter',
+          500 clamp(20px, 3.4vh, 34px)/1.05 'Inter',
           sans-serif;
       }
       .video-chrome {
@@ -2606,13 +2606,16 @@
         </div>
         <video
           class="hero-video"
-          src="https://github.com/microsoft/Huabu/releases/download/v0.9.0/Huabu-Video.mp4"
           poster="./Huabu-Video-Poster.jpg"
           controls
           preload="metadata"
           playsinline
           aria-label="Huabu product demo video"
         >
+          <source
+            src="https://github.com/microsoft/Huabu/releases/download/v0.9.0/Huabu-Video.mp4"
+            type="video/mp4"
+          />
           <track
             kind="subtitles"
             src="./Huabu-Video.vtt"

--- a/apps/docs/landingpage/index.html
+++ b/apps/docs/landingpage/index.html
@@ -2617,7 +2617,7 @@
             type="video/mp4"
           />
           <track
-            kind="subtitles"
+            kind="captions"
             src="./Huabu-Video.vtt"
             srclang="en"
             label="English"

--- a/apps/docs/landingpage/index.html
+++ b/apps/docs/landingpage/index.html
@@ -328,6 +328,19 @@
         object-fit: cover;
         background: #000;
       }
+      .hero-video:fullscreen,
+      .hero-video:-webkit-full-screen {
+        object-fit: contain;
+      }
+      .hero-video::cue {
+        font: 500 1.7vw/1.05 'Inter', sans-serif;
+        color: #fff;
+        background: rgba(0, 0, 0, 0.55);
+      }
+      .hero-video:fullscreen::cue,
+      .hero-video:-webkit-full-screen::cue {
+        font: 500 3.4vh/1.05 'Inter', sans-serif;
+      }
       .video-chrome {
         position: relative;
         height: 38px;
@@ -2595,7 +2608,15 @@
           preload="metadata"
           playsinline
           aria-label="Huabu product demo video"
-        ></video>
+        >
+          <track
+            kind="subtitles"
+            src="./Huabu-Video.vtt"
+            srclang="en"
+            label="English"
+            default
+          />
+        </video>
       </div>
     </header>
 

--- a/apps/docs/landingpage/index.html
+++ b/apps/docs/landingpage/index.html
@@ -333,13 +333,17 @@
         object-fit: contain;
       }
       .hero-video::cue {
-        font: 500 1.7vw/1.05 'Inter', sans-serif;
+        font:
+          500 1.7vw/1.05 'Inter',
+          sans-serif;
         color: #fff;
         background: rgba(0, 0, 0, 0.55);
       }
       .hero-video:fullscreen::cue,
       .hero-video:-webkit-full-screen::cue {
-        font: 500 3.4vh/1.05 'Inter', sans-serif;
+        font:
+          500 3.4vh/1.05 'Inter',
+          sans-serif;
       }
       .video-chrome {
         position: relative;


### PR DESCRIPTION
Exports the embedded English subtitle track as a browser-compatible .vtt file for use with the HTML <video> <track> element. The file contains 15 subtitles synchronized with the final video.