### PR TITLE
Enhance mobile responsiveness of handbook and fix layout issues

### DIFF
--- a/apps/docs/src/DocsLayout.tsx
+++ b/apps/docs/src/DocsLayout.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { Github, Menu, X } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link, NavLink, useLocation } from 'react-router-dom';
 
 import { withBasePath } from './basePath';
@@ -10,7 +10,14 @@ import { cn } from './components/cn';
 import { Search } from './components/Search';
 import { groups, pinnedItems, type DocsItem } from './navigation';
 
-import type { CSSProperties, ReactNode } from 'react';
+import type {
+  CSSProperties,
+  KeyboardEvent as ReactKeyboardEvent,
+  ReactNode,
+  RefObject,
+} from 'react';
+
+const desktopLayoutQuery = '(min-width: 64rem)';
 
 /**
  * Shell for every page on the standalone handbook site.
@@ -36,6 +43,11 @@ import type { CSSProperties, ReactNode } from 'react';
  */
 export function DocsLayout({ children }: { children: ReactNode }) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const mobileHeaderRef = useRef<HTMLElement>(null);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const sidebarRef = useRef<HTMLElement>(null);
+  const sidebarCloseButtonRef = useRef<HTMLButtonElement>(null);
+  const mainRef = useRef<HTMLElement>(null);
   const { pathname } = useLocation();
 
   // Close the mobile drawer on navigation so tapping a link doesn't
@@ -44,25 +56,42 @@ export function DocsLayout({ children }: { children: ReactNode }) {
     setIsSidebarOpen(false);
   }, [pathname]);
 
-  // Lock body scroll while the mobile drawer is open.
+  // Keep the closed mobile drawer out of the tab order. Crossing into
+  // the desktop layout also closes it so body scroll is restored.
   useEffect(() => {
+    const mediaQuery = window.matchMedia(desktopLayoutQuery);
+    const syncLayout = () => {
+      if (mediaQuery.matches) {
+        setIsSidebarOpen(false);
+        sidebarRef.current?.removeAttribute('inert');
+      } else {
+        sidebarRef.current?.toggleAttribute('inert', !isSidebarOpen);
+      }
+    };
+
+    syncLayout();
+    mediaQuery.addEventListener('change', syncLayout);
+    return () => mediaQuery.removeEventListener('change', syncLayout);
+  }, [isSidebarOpen]);
+
+  // Isolate the open drawer, lock body scroll, and move focus into it.
+  useEffect(() => {
+    mobileHeaderRef.current?.toggleAttribute('inert', isSidebarOpen);
+    mainRef.current?.toggleAttribute('inert', isSidebarOpen);
     if (!isSidebarOpen) return;
+
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
+    sidebarCloseButtonRef.current?.focus();
     return () => {
       document.body.style.overflow = previousOverflow;
     };
   }, [isSidebarOpen]);
 
-  // Close on Escape for keyboard users.
-  useEffect(() => {
-    if (!isSidebarOpen) return;
-    const handleKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setIsSidebarOpen(false);
-    };
-    document.addEventListener('keydown', handleKey);
-    return () => document.removeEventListener('keydown', handleKey);
-  }, [isSidebarOpen]);
+  const closeSidebar = () => {
+    setIsSidebarOpen(false);
+    window.requestAnimationFrame(() => menuButtonRef.current?.focus());
+  };
 
   return (
     <div
@@ -78,36 +107,64 @@ export function DocsLayout({ children }: { children: ReactNode }) {
         } as CSSProperties
       }
     >
-      <MobileHeader onOpen={() => setIsSidebarOpen(true)} />
+      <MobileHeader
+        headerRef={mobileHeaderRef}
+        menuButtonRef={menuButtonRef}
+        isSidebarOpen={isSidebarOpen}
+        onOpen={() => setIsSidebarOpen(true)}
+      />
 
       {/* Backdrop for the mobile drawer. */}
       {isSidebarOpen && (
         <button
           type="button"
           aria-label="Close navigation"
+          aria-hidden="true"
+          tabIndex={-1}
           className="fixed inset-0 z-30 bg-black/40 lg:hidden"
-          onClick={() => setIsSidebarOpen(false)}
+          onClick={closeSidebar}
         />
       )}
 
       <DocsSidebar
+        sidebarRef={sidebarRef}
+        closeButtonRef={sidebarCloseButtonRef}
         isOpen={isSidebarOpen}
-        onClose={() => setIsSidebarOpen(false)}
+        onClose={closeSidebar}
       />
-      <main className="min-h-full px-5 pt-14.25 lg:px-0 lg:pt-0 lg:pl-[calc(var(--docs-sidebar-right-edge)+var(--docs-gutter))] lg:pr-(--docs-gutter)">
+      <main
+        ref={mainRef}
+        className="min-h-full px-5 pt-14.25 lg:px-0 lg:pt-0 lg:pl-[calc(var(--docs-sidebar-right-edge)+var(--docs-gutter))] lg:pr-(--docs-gutter)"
+      >
         {children}
       </main>
     </div>
   );
 }
 
-function MobileHeader({ onOpen }: { onOpen: () => void }) {
+function MobileHeader({
+  headerRef,
+  menuButtonRef,
+  isSidebarOpen,
+  onOpen,
+}: {
+  headerRef: RefObject<HTMLElement>;
+  menuButtonRef: RefObject<HTMLButtonElement>;
+  isSidebarOpen: boolean;
+  onOpen: () => void;
+}) {
   return (
-    <header className="fixed top-0 right-0 left-0 z-20 flex items-center gap-3 border-b border-gray-200 bg-white/90 px-4 py-3 backdrop-blur lg:hidden">
+    <header
+      ref={headerRef}
+      className="fixed top-0 right-0 left-0 z-20 flex items-center gap-3 border-b border-gray-200 bg-white/90 px-4 py-3 backdrop-blur lg:hidden"
+    >
       <button
+        ref={menuButtonRef}
         type="button"
         onClick={onOpen}
         aria-label="Open navigation"
+        aria-controls="docs-sidebar"
+        aria-expanded={isSidebarOpen}
         className="flex h-9 w-9 items-center justify-center rounded-md text-gray-700 transition-colors hover:bg-gray-100"
       >
         <Menu aria-hidden="true" className="h-5 w-5" />
@@ -139,16 +196,51 @@ const sidebarLinkClass = ({ isActive }: { isActive: boolean }) =>
   );
 
 function DocsSidebar({
+  sidebarRef,
+  closeButtonRef,
   isOpen,
   onClose,
 }: {
+  sidebarRef: RefObject<HTMLElement>;
+  closeButtonRef: RefObject<HTMLButtonElement>;
   isOpen: boolean;
   onClose: () => void;
 }) {
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
+    if (!isOpen) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+
+    const focusable = Array.from(
+      event.currentTarget.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    ).filter((element) => !element.hidden && element.offsetParent !== null);
+    if (focusable.length === 0) return;
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last?.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first?.focus();
+    }
+  };
+
   return (
     <aside
+      id="docs-sidebar"
+      ref={sidebarRef}
+      aria-label="Handbook navigation"
+      onKeyDown={handleKeyDown}
       className={cn(
-        'fixed top-4 bottom-4 left-4 z-40 flex w-60 flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-[0_2px_12px_rgba(0,0,0,0.04)] transition-transform duration-200 ease-out lg:z-20 lg:translate-x-0',
+        'fixed top-4 bottom-4 left-4 z-40 flex w-60 flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-[0_2px_12px_rgba(0,0,0,0.04)] transition-transform duration-200 ease-out motion-reduce:transition-none lg:z-20 lg:translate-x-0',
         isOpen ? 'translate-x-0' : '-translate-x-[calc(100%+1rem)]',
       )}
     >
@@ -169,6 +261,7 @@ function DocsSidebar({
             Handbook
           </Link>
           <button
+            ref={closeButtonRef}
             type="button"
             onClick={onClose}
             aria-label="Close navigation"

--- a/apps/docs/src/DocsLayout.tsx
+++ b/apps/docs/src/DocsLayout.tsx
@@ -90,6 +90,11 @@ export function DocsLayout({ children }: { children: ReactNode }) {
 
   const closeSidebar = () => {
     setIsSidebarOpen(false);
+    // Clear inert synchronously so focus can land on the menu button:
+    // the passive effect that normally removes it runs after the next
+    // paint, but requestAnimationFrame fires before it.
+    mobileHeaderRef.current?.removeAttribute('inert');
+    mainRef.current?.removeAttribute('inert');
     window.requestAnimationFrame(() => menuButtonRef.current?.focus());
   };
 
@@ -118,7 +123,6 @@ export function DocsLayout({ children }: { children: ReactNode }) {
       {isSidebarOpen && (
         <button
           type="button"
-          aria-label="Close navigation"
           aria-hidden="true"
           tabIndex={-1}
           className="fixed inset-0 z-30 bg-black/40 lg:hidden"
@@ -134,7 +138,7 @@ export function DocsLayout({ children }: { children: ReactNode }) {
       />
       <main
         ref={mainRef}
-        className="min-h-full px-5 pt-14.25 lg:px-0 lg:pt-0 lg:pl-[calc(var(--docs-sidebar-right-edge)+var(--docs-gutter))] lg:pr-(--docs-gutter)"
+        className="min-h-full px-5 pt-14.25 lg:px-0 lg:pt-0 lg:pr-(--docs-gutter) lg:pl-[calc(var(--docs-sidebar-right-edge)+var(--docs-gutter))]"
       >
         {children}
       </main>

--- a/apps/docs/src/DocsLayout.tsx
+++ b/apps/docs/src/DocsLayout.tsx
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Github } from 'lucide-react';
-import { Link, NavLink } from 'react-router-dom';
+import { Github, Menu, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Link, NavLink, useLocation } from 'react-router-dom';
 
 import { withBasePath } from './basePath';
 import { cn } from './components/cn';
@@ -15,11 +16,15 @@ import type { CSSProperties, ReactNode } from 'react';
  * Shell for every page on the standalone handbook site.
  *
  * Layout:
- * - Floating sidebar pinned to the viewport on the left (logo +
- *   pinned shortcuts always visible; groups scroll below).
- * - Main content area on the right owns the article content.
+ * - On `lg` and up: a floating sidebar pinned to the viewport on the
+ *   left (logo + pinned shortcuts always visible; groups scroll
+ *   below), and the main content area on the right owns the article.
+ * - Below `lg`: the sidebar collapses into a slide-in drawer toggled
+ *   from a sticky mobile header, and the main content spans the full
+ *   width with compact side padding.
  *
- * Horizontal spacing (kept consistent across every section page):
+ * Horizontal spacing on `lg`+ (kept consistent across every section
+ * page):
  * - Sidebar occupies `left-4 + w-60` = 256px from the viewport's
  *   left edge to its right edge.
  * - `--docs-gutter` (= 1/5 of the space remaining after the sidebar)
@@ -30,6 +35,35 @@ import type { CSSProperties, ReactNode } from 'react';
  * The module has no product-application dependency.
  */
 export function DocsLayout({ children }: { children: ReactNode }) {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const { pathname } = useLocation();
+
+  // Close the mobile drawer on navigation so tapping a link doesn't
+  // leave the overlay covering the freshly loaded page.
+  useEffect(() => {
+    setIsSidebarOpen(false);
+  }, [pathname]);
+
+  // Lock body scroll while the mobile drawer is open.
+  useEffect(() => {
+    if (!isSidebarOpen) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isSidebarOpen]);
+
+  // Close on Escape for keyboard users.
+  useEffect(() => {
+    if (!isSidebarOpen) return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsSidebarOpen(false);
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [isSidebarOpen]);
+
   return (
     <div
       className="relative h-full w-full overflow-y-auto bg-white"
@@ -44,18 +78,55 @@ export function DocsLayout({ children }: { children: ReactNode }) {
         } as CSSProperties
       }
     >
-      <DocsSidebar />
-      <main
-        className="min-h-full"
-        style={{
-          paddingLeft:
-            'calc(var(--docs-sidebar-right-edge) + var(--docs-gutter))',
-          paddingRight: 'var(--docs-gutter)',
-        }}
-      >
+      <MobileHeader onOpen={() => setIsSidebarOpen(true)} />
+
+      {/* Backdrop for the mobile drawer. */}
+      {isSidebarOpen && (
+        <button
+          type="button"
+          aria-label="Close navigation"
+          className="fixed inset-0 z-30 bg-black/40 lg:hidden"
+          onClick={() => setIsSidebarOpen(false)}
+        />
+      )}
+
+      <DocsSidebar
+        isOpen={isSidebarOpen}
+        onClose={() => setIsSidebarOpen(false)}
+      />
+      <main className="min-h-full px-5 pt-14.25 lg:px-0 lg:pt-0 lg:pl-[calc(var(--docs-sidebar-right-edge)+var(--docs-gutter))] lg:pr-(--docs-gutter)">
         {children}
       </main>
     </div>
+  );
+}
+
+function MobileHeader({ onOpen }: { onOpen: () => void }) {
+  return (
+    <header className="fixed top-0 right-0 left-0 z-20 flex items-center gap-3 border-b border-gray-200 bg-white/90 px-4 py-3 backdrop-blur lg:hidden">
+      <button
+        type="button"
+        onClick={onOpen}
+        aria-label="Open navigation"
+        className="flex h-9 w-9 items-center justify-center rounded-md text-gray-700 transition-colors hover:bg-gray-100"
+      >
+        <Menu aria-hidden="true" className="h-5 w-5" />
+      </button>
+      <a
+        href={withBasePath('/')}
+        aria-label="Huabu home"
+        title="Huabu home"
+        className="rounded transition-opacity hover:opacity-70"
+      >
+        <img src={withBasePath('favicon.svg')} alt="" className="h-5 w-5" />
+      </a>
+      <Link
+        to="/docs"
+        className="text-[15px] font-semibold text-gray-900 transition-colors hover:text-gray-600"
+      >
+        Handbook
+      </Link>
+    </header>
   );
 }
 
@@ -67,9 +138,20 @@ const sidebarLinkClass = ({ isActive }: { isActive: boolean }) =>
       : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900',
   );
 
-function DocsSidebar() {
+function DocsSidebar({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+}) {
   return (
-    <aside className="fixed top-4 bottom-4 left-4 z-20 flex w-60 flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-[0_2px_12px_rgba(0,0,0,0.04)]">
+    <aside
+      className={cn(
+        'fixed top-4 bottom-4 left-4 z-40 flex w-60 flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-[0_2px_12px_rgba(0,0,0,0.04)] transition-transform duration-200 ease-out lg:z-20 lg:translate-x-0',
+        isOpen ? 'translate-x-0' : '-translate-x-[calc(100%+1rem)]',
+      )}
+    >
       {/* Pinned header: logo + brand + the two universal entry points
               (Overview / Quick Start). Stays put when the lower list
               scrolls. */}
@@ -86,6 +168,14 @@ function DocsSidebar() {
           <Link to="/docs" className="transition-colors hover:text-gray-600">
             Handbook
           </Link>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close navigation"
+            className="ml-auto flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 lg:hidden"
+          >
+            <X aria-hidden="true" className="h-5 w-5" />
+          </button>
         </div>
         <Search />
         <ul className="space-y-0.5">

--- a/apps/docs/src/sections/ai/AgentNodeStatusGuide.css
+++ b/apps/docs/src/sections/ai/AgentNodeStatusGuide.css
@@ -369,6 +369,11 @@
   .agent-status-grid {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
+  /* 7 examples leave one trailing cell empty in a 4-col layout; let
+     the last card fill it so the grey grid background never shows. */
+  .agent-status-example:last-child {
+    grid-column: span 2;
+  }
 }
 
 @media (max-width: 760px) {


### PR DESCRIPTION
This pull request introduces a responsive mobile sidebar navigation experience for the documentation site, improving accessibility and usability on smaller screens. The sidebar now collapses into a slide-in drawer on mobile, complete with keyboard navigation support, focus management, and body scroll locking. Additionally, a small visual tweak ensures that the last card in the agent status grid fills empty space on large screens.

**Responsive sidebar and navigation improvements:**

* Refactored `DocsLayout` to manage sidebar open/close state, handle focus trapping, and lock body scroll when the mobile drawer is open. The sidebar automatically closes on navigation and adapts to viewport changes. (`apps/docs/src/DocsLayout.tsx`) [[1]](diffhunk://#diff-e5986bb655c13c4bd536de46328c3e6a9d4c6264dee48fb7e7f92b44f98b8ea4L4-R34) [[2]](diffhunk://#diff-e5986bb655c13c4bd536de46328c3e6a9d4c6264dee48fb7e7f92b44f98b8ea4R45-R95)
* Added a `MobileHeader` component with a menu button to open the sidebar on mobile devices, and a backdrop overlay that closes the sidebar when clicked. (`apps/docs/src/DocsLayout.tsx`)
* Updated `DocsSidebar` to support being opened/closed, trap keyboard focus, and provide an accessible close button. The sidebar animates in/out and is hidden from tab order and assistive tech when closed. (`apps/docs/src/DocsLayout.tsx`) [[1]](diffhunk://#diff-e5986bb655c13c4bd536de46328c3e6a9d4c6264dee48fb7e7f92b44f98b8ea4L70-R246) [[2]](diffhunk://#diff-e5986bb655c13c4bd536de46328c3e6a9d4c6264dee48fb7e7f92b44f98b8ea4R263-R271)

**Visual polish:**

* Modified the agent status grid so that, on large screens, the last example card spans two columns if it would otherwise leave an empty cell, preventing the grid background from showing through. (`apps/docs/src/sections/ai/AgentNodeStatusGuide.css`)