### PR TITLE
build(mac): add Intel x64 installers

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -117,6 +117,7 @@ mac:
     - target: dmg
       arch:
         - arm64
+        - x64
     # Squirrel.Mac (the macOS auto-update engine electron-updater drives)
     # applies updates from a `.zip`, not the `.dmg`. `latest-mac.yml`
     # references this zip; without it macOS auto-update cannot install a
@@ -124,6 +125,7 @@ mac:
     - target: zip
       arch:
         - arm64
+        - x64
   category: public.app-category.productivity
   darkModeSupport: true
   # Sign + notarize in CI. The Developer ID certificate arrives via the


### PR DESCRIPTION
﻿## Summary

- add `x64` alongside `arm64` for the macOS DMG target
- add `x64` alongside `arm64` for the macOS ZIP/update target

This addresses #46 by producing Intel Mac installers while preserving the existing Apple-silicon artifacts. The release workflow already uploads all matching DMG, ZIP, blockmap, and `latest-mac.yml` assets, so no workflow change is needed.

## Validation

- parsed `apps/desktop/electron-builder.yml` successfully with PyYAML
- `git diff --check` passes
- a local desktop package build was not run because this checkout does not have the pinned Node `22.22.0` runtime and dependencies installed

This small patch was prepared with AI assistance and reviewed against the existing electron-builder and release workflow configuration.
