### PR TITLE
Fix stalled note auto-height commits

### DIFF
--- a/apps/web/e2e/note-auto-height.spec.ts
+++ b/apps/web/e2e/note-auto-height.spec.ts
@@ -57,6 +57,50 @@ async function pasteNote(page: Page, markdown: string): Promise<void> {
 }
 
 /**
+ * Create a note through the same headless endpoint used by agents.
+ * The open tab receives the server-authored insertion through canvas sync;
+ * no UI creation path runs locally before the note is measured.
+ */
+async function executeAgentCommands(
+  page: Page,
+  commands: unknown[],
+): Promise<Record<string, unknown>> {
+  const canvasId = page.url().split('/canvas/')[1]?.split(/[?#]/)[0];
+  if (!canvasId) throw new Error('canvas id not found in URL');
+
+  const response = await page.request.post(`/api/canvas/${canvasId}/execute`, {
+    data: {
+      commands,
+      originator: { source: 'agent', threadId: 'e2e-auto-height' },
+    },
+  });
+
+  expect(response.ok(), await response.text()).toBe(true);
+  return (await response.json()) as Record<string, unknown>;
+}
+
+async function createAgentNote(
+  page: Page,
+  markdown: string,
+  parentId?: string,
+): Promise<void> {
+  await executeAgentCommands(page, [
+    {
+      type: 'CREATE_NODES',
+      nodes: [
+        {
+          nodeType: 'note',
+          data: { label: 'Agent long note', content: markdown },
+          position: { x: 100, y: 100 },
+          size: { width: 560, height: 'auto' },
+          ...(parentId ? { parentId } : {}),
+        },
+      ],
+    },
+  ]);
+}
+
+/**
  * For every mounted note, how many pixels its content overflows the box
  * it was given. The reader mirrors `readNoteIntrinsicHeight`: measure
  * `.ProseMirror` (not the host, whose `scrollHeight` Crepe's absolutely
@@ -116,6 +160,129 @@ async function pasteAllFixtures(page: Page): Promise<string[]> {
 }
 
 test.describe('note auto height', () => {
+  test('an agent-created long note replaces its initial height hint', async ({
+    page,
+  }) => {
+    await openNewCanvas(page);
+    const markdown = Array.from(
+      { length: 12 },
+      (_, index) =>
+        `## Section ${index + 1}\n\nThis paragraph is long enough to wrap at the note width and must contribute to the measured height.`,
+    ).join('\n\n');
+
+    await createAgentNote(page, markdown);
+
+    const note = page.locator('.react-flow__node').filter({
+      has: page.locator('[data-note-content-host]'),
+    });
+    await expect(note).toHaveCount(1);
+    await expect(note.locator('.ProseMirror')).toHaveCount(1);
+
+    await expect
+      .poll(async () => {
+        const height = await note.evaluate((element) =>
+          parseFloat((element as HTMLElement).style.height),
+        );
+        return height;
+      })
+      .toBeGreaterThan(200);
+
+    const [overflow] = await measureOverflows(page);
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+
+  test('an agent-created long note grows inside a structured frame', async ({
+    page,
+  }) => {
+    await openNewCanvas(page);
+    const frameResponse = await executeAgentCommands(page, [
+      {
+        type: 'CREATE_NODES',
+        nodes: [
+          {
+            nodeType: 'frame',
+            data: { label: 'Agent frame' },
+            position: { x: 50, y: 50 },
+          },
+        ],
+      },
+    ]);
+    const results = frameResponse.results as Array<{
+      nodes?: Array<{ nodeId: string }>;
+    }>;
+    const frameId = results[0]?.nodes?.[0]?.nodeId;
+    expect(frameId).toBeTruthy();
+
+    await executeAgentCommands(page, [
+      {
+        type: 'SET_FRAME_LAYOUT',
+        frameId,
+        mode: 'column',
+        gridCount: 1,
+        sizing: 'hug',
+      },
+    ]);
+
+    const markdown = Array.from(
+      { length: 12 },
+      (_, index) =>
+        `## Framed section ${index + 1}\n\nThis paragraph must expand both the auto-height note and its structured parent frame.`,
+    ).join('\n\n');
+    await createAgentNote(page, markdown, frameId);
+
+    const note = page.locator('.react-flow__node-note');
+    await expect(note.locator('.ProseMirror')).toHaveCount(1);
+    await expect
+      .poll(() =>
+        note.evaluate((element) =>
+          parseFloat((element as HTMLElement).style.height),
+        ),
+      )
+      .toBeGreaterThan(200);
+
+    const [overflow] = await measureOverflows(page);
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+
+  test('a manually pasted note grows after mounted editing', async ({
+    page,
+  }) => {
+    await openNewCanvas(page);
+    const centre = await paneCenter(page);
+    await page.mouse.move(centre.x, centre.y);
+    await pasteNote(page, 'Short note\n\nInitial body.');
+
+    const note = page.locator('.react-flow__node-note');
+    await expect(note.locator('.ProseMirror')).toHaveCount(1);
+    const initialHeight = await note.evaluate((element) =>
+      parseFloat((element as HTMLElement).style.height),
+    );
+
+    const editor = page.locator(
+      '[data-search-scope="node"] .ProseMirror[contenteditable="true"]',
+    );
+    await expect(editor).toHaveCount(1);
+
+    const longContent = Array.from(
+      { length: 12 },
+      (_, index) =>
+        `Section ${index + 1}. This manually edited paragraph is long enough to wrap and must expand the mounted note.`,
+    ).join('\n\n');
+    await editor.fill(longContent);
+    await page.getByRole('button', { name: 'Close', exact: true }).click();
+
+    await expect
+      .poll(() =>
+        note.evaluate((element) =>
+          parseFloat((element as HTMLElement).style.height),
+        ),
+      )
+      .toBeGreaterThan(initialHeight + 100);
+
+    const [overflow] = await measureOverflows(page);
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+
   test('every auto note fits the content it was measured from', async ({
     page,
   }) => {

--- a/apps/web/src/components/Nodes/NodeWrapper.tsx
+++ b/apps/web/src/components/Nodes/NodeWrapper.tsx
@@ -532,7 +532,7 @@ export const NodeWrapper = memo(
         // Paired with the `suspendHeightCommits` in `onNodeResizeStart`.
         // Released after the geometry commit so a queued correction is
         // evaluated against the node's final width.
-        resumeHeightCommits();
+        resumeHeightCommits('node-resize');
       },
       [
         endResizePreview,

--- a/apps/web/src/components/Nodes/shared/height/__tests__/commitQueue.test.ts
+++ b/apps/web/src/components/Nodes/shared/height/__tests__/commitQueue.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../commitQueue';
 import {
   __resetHeightCommitSuspension,
+  cancelHeightCommitSuspensions,
   resumeHeightCommits,
   suspendHeightCommits,
 } from '../commitSuspension';
@@ -239,6 +240,52 @@ describe('height commit queue — gesture suspension', () => {
     expect(applyMeasuredHeights).not.toHaveBeenCalled();
 
     resumeHeightCommits();
+    __flushHeightCommitsNow();
+    expect(applyMeasuredHeights).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats duplicate starts for the same interaction as one hold', () => {
+    suspendHeightCommits('viewport');
+    suspendHeightCommits('viewport');
+    proposeMeasuredHeight({
+      nodeId: 'n1',
+      intrinsicHeight: 400,
+      measuredFor: 'k1',
+    });
+
+    resumeHeightCommits('viewport');
+    __flushHeightCommitsNow();
+    expect(applyMeasuredHeights).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not release an active gesture based on elapsed time', () => {
+    vi.useFakeTimers();
+    suspendHeightCommits('node-drag');
+    proposeMeasuredHeight({
+      nodeId: 'n1',
+      intrinsicHeight: 400,
+      measuredFor: 'k1',
+    });
+
+    vi.advanceTimersByTime(60_000);
+    __flushHeightCommitsNow();
+    expect(applyMeasuredHeights).not.toHaveBeenCalled();
+
+    resumeHeightCommits('node-drag');
+    __flushHeightCommitsNow();
+    expect(applyMeasuredHeights).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it('flushes named holds after an explicit cancellation signal', () => {
+    suspendHeightCommits('node-drag');
+    proposeMeasuredHeight({
+      nodeId: 'n1',
+      intrinsicHeight: 400,
+      measuredFor: 'k1',
+    });
+
+    cancelHeightCommitSuspensions();
     __flushHeightCommitsNow();
     expect(applyMeasuredHeights).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/src/components/Nodes/shared/height/commitSuspension.ts
+++ b/apps/web/src/components/Nodes/shared/height/commitSuspension.ts
@@ -17,28 +17,45 @@
 
 type SettleListener = () => void;
 
-let depth = 0;
+export type HeightCommitSuspension = 'viewport' | 'node-drag' | 'node-resize';
+
+const namedHolds = new Set<HeightCommitSuspension>();
+let anonymousDepth = 0;
 const listeners = new Set<SettleListener>();
 
 /**
  * Hold back derived-geometry writes. Every call must be paired with
  * {@link resumeHeightCommits}.
  */
-export function suspendHeightCommits(): void {
-  depth += 1;
+export function suspendHeightCommits(reason?: HeightCommitSuspension): void {
+  if (!reason) {
+    anonymousDepth += 1;
+    return;
+  }
+  namedHolds.add(reason);
 }
 
 /** Release one hold; notifies listeners when the last one clears. */
-export function resumeHeightCommits(): void {
-  if (depth === 0) return;
-  depth -= 1;
-  if (depth > 0) return;
-  for (const listener of listeners) listener();
+export function resumeHeightCommits(reason?: HeightCommitSuspension): void {
+  const wasSuspended = isHeightCommitSuspended();
+  if (reason) {
+    namedHolds.delete(reason);
+  } else if (anonymousDepth > 0) anonymousDepth -= 1;
+  if (!wasSuspended || isHeightCommitSuspended()) return;
+  notifySettled();
+}
+
+/** Release named interaction holds after an explicit cancellation signal. */
+export function cancelHeightCommitSuspensions(): void {
+  const wasSuspended = isHeightCommitSuspended();
+  namedHolds.clear();
+  if (!wasSuspended || isHeightCommitSuspended()) return;
+  notifySettled();
 }
 
 /** True while any interaction is in progress. */
 export function isHeightCommitSuspended(): boolean {
-  return depth > 0;
+  return anonymousDepth > 0 || namedHolds.size > 0;
 }
 
 /** Run `listener` each time the last active interaction settles. */
@@ -47,7 +64,12 @@ export function onHeightCommitsSettled(listener: SettleListener): () => void {
   return () => listeners.delete(listener);
 }
 
+function notifySettled(): void {
+  for (const listener of listeners) listener();
+}
+
 /** Test seam: forget all holds and listeners. */
 export function __resetHeightCommitSuspension(): void {
-  depth = 0;
+  anonymousDepth = 0;
+  namedHolds.clear();
 }

--- a/apps/web/src/components/Nodes/shared/height/commitSuspension.ts
+++ b/apps/web/src/components/Nodes/shared/height/commitSuspension.ts
@@ -68,7 +68,7 @@ function notifySettled(): void {
   for (const listener of listeners) listener();
 }
 
-/** Test seam: forget all holds and listeners. */
+/** Test seam: forget all holds. */
 export function __resetHeightCommitSuspension(): void {
   anonymousDepth = 0;
   namedHolds.clear();

--- a/apps/web/src/components/Nodes/shared/height/measure/__tests__/prewarmQueue.test.ts
+++ b/apps/web/src/components/Nodes/shared/height/measure/__tests__/prewarmQueue.test.ts
@@ -1,19 +1,52 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 
 import { HEIGHT_LAYOUT_VERSION } from '@huabu/shared/canvas-engine';
 import { nodeRevisionOf } from '@huabu/shared/canvas-engine';
 
-import { selectPrewarmCandidates } from '../prewarmQueue';
+import {
+  __resetHeightCommitSuspension,
+  resumeHeightCommits,
+  suspendHeightCommits,
+} from '../../commitSuspension';
+import {
+  __resetHeightPrewarm,
+  selectPrewarmCandidates,
+  startHeightPrewarm,
+} from '../prewarmQueue';
 
 import type { Node } from '@xyflow/react';
 
-vi.mock('@/store/canvasStore', () => ({ default: { getState: () => ({}) } }));
+const mocks = vi.hoisted(() => ({
+  state: {
+    nodes: [] as Node[],
+    viewport: null,
+    canvasId: 'canvas-test',
+  },
+  subscriber: null as (() => void) | null,
+  measure: vi.fn(),
+  propose: vi.fn(),
+}));
+
+vi.mock('@/store/canvasStore', () => ({
+  default: {
+    getState: () => mocks.state,
+    subscribe: (subscriber: () => void) => {
+      mocks.subscriber = subscriber;
+      return () => {
+        mocks.subscriber = null;
+      };
+    },
+  },
+}));
 vi.mock('../offscreenMeasurer', () => ({
-  measureNoteHeightOffscreen: vi.fn(),
+  measureNoteHeightOffscreen: mocks.measure,
   destroyOffscreenMeasurer: vi.fn(),
+}));
+vi.mock('../../commitQueue', () => ({
+  proposeMeasuredHeight: mocks.propose,
 }));
 
 const CONTENT = '# hello';
@@ -30,6 +63,16 @@ function note(overrides: Partial<Node> = {}): Node {
     ...overrides,
   } as Node;
 }
+
+afterEach(() => {
+  __resetHeightPrewarm();
+  __resetHeightCommitSuspension();
+  vi.restoreAllMocks();
+  mocks.state.nodes = [];
+  mocks.measure.mockReset();
+  mocks.propose.mockReset();
+  vi.useRealTimers();
+});
 
 describe('selectPrewarmCandidates', () => {
   it('picks up a note that has never been measured', () => {
@@ -115,5 +158,84 @@ describe('selectPrewarmCandidates', () => {
   it('does not re-offer a node already attempted under the same key', () => {
     const attempts = new Set([`n1:${KEY}`]);
     expect(selectPrewarmCandidates([note()], ORIGIN, attempts)).toHaveLength(0);
+  });
+});
+
+describe('height prewarm recovery', () => {
+  it('retries a transient measurement failure and commits the result', async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mocks.state.nodes = [note()];
+    const error = new Error('transient editor failure');
+    mocks.measure
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce({ height: 320, provisional: false });
+
+    startHeightPrewarm();
+    await vi.advanceTimersByTimeAsync(2500);
+
+    expect(mocks.measure).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledWith(
+      '[height] offscreen note measurement failed; retrying',
+      {
+        nodeId: 'n1',
+        measuredFor: KEY,
+        attempt: 1,
+        retryInMs: 1000,
+        error,
+      },
+    );
+    expect(mocks.propose).toHaveBeenCalledWith({
+      nodeId: 'n1',
+      intrinsicHeight: 320,
+      measuredFor: KEY,
+      provisional: false,
+    });
+  });
+
+  it('retries when a measured proposal does not produce a stored hint', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mocks.state.nodes = [note()];
+    mocks.measure.mockResolvedValue({ height: 320, provisional: false });
+    mocks.propose
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        mocks.state.nodes = [
+          note({
+            data: {
+              type: 'note',
+              content: CONTENT,
+              heightMode: 'auto',
+              autoHeight: { intrinsicHeight: 320, measuredFor: KEY },
+            },
+          }),
+        ];
+      });
+
+    startHeightPrewarm();
+    await vi.advanceTimersByTimeAsync(3500);
+
+    expect(mocks.measure).toHaveBeenCalledTimes(2);
+    expect(mocks.propose).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not confirm or retry a proposal while commits are suspended', async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mocks.state.nodes = [note()];
+    mocks.measure.mockResolvedValue({ height: 320, provisional: false });
+    suspendHeightCommits('node-drag');
+
+    startHeightPrewarm();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(mocks.measure).toHaveBeenCalledTimes(1);
+    expect(mocks.propose).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+
+    resumeHeightCommits('node-drag');
+    await vi.advanceTimersByTimeAsync(2500);
+    expect(mocks.measure).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/src/components/Nodes/shared/height/measure/offscreenMeasurer.ts
+++ b/apps/web/src/components/Nodes/shared/height/measure/offscreenMeasurer.ts
@@ -89,7 +89,13 @@ async function measureNow(
 }
 
 async function ensureHost(): Promise<Host> {
-  hostPromise ??= buildHost();
+  hostPromise ??= buildHost().catch((error: unknown) => {
+    // A rejected singleton would otherwise poison every later measurement
+    // in this app session. Clear it so the prewarm queue's retry can build a
+    // fresh editor after a transient chunk-load or Milkdown mount failure.
+    hostPromise = null;
+    throw error;
+  });
   return hostPromise;
 }
 

--- a/apps/web/src/components/Nodes/shared/height/measure/prewarmQueue.ts
+++ b/apps/web/src/components/Nodes/shared/height/measure/prewarmQueue.ts
@@ -206,7 +206,10 @@ function confirmCommit(candidate: PrewarmCandidate): void {
       failureCounts.delete(key);
       return;
     }
-    if (autoHeightKey(node) !== candidate.measuredFor) return;
+    if (autoHeightKey(node) !== candidate.measuredFor) {
+      failureCounts.delete(key);
+      return;
+    }
     scheduleRetry(candidate, new Error('measured height was not committed'));
   }, COMMIT_CONFIRM_MS);
   commitCheckHandles.set(key, handle);

--- a/apps/web/src/components/Nodes/shared/height/measure/prewarmQueue.ts
+++ b/apps/web/src/components/Nodes/shared/height/measure/prewarmQueue.ts
@@ -33,6 +33,10 @@ import {
 import useCanvasStore from '@/store/canvasStore';
 
 import { proposeMeasuredHeight } from '../commitQueue';
+import {
+  isHeightCommitSuspended,
+  onHeightCommitsSettled,
+} from '../commitSuspension';
 import { measureNoteHeightOffscreen } from './offscreenMeasurer';
 
 import type { Node } from '@xyflow/react';
@@ -42,6 +46,15 @@ const BATCH_SIZE = 3;
 
 /** Re-scan this long after the last store change settles. */
 const RESCAN_DEBOUNCE_MS = 400;
+
+/** Allow the rAF-coalesced commit queue time to write the measured hint. */
+const COMMIT_CONFIRM_MS = 1000;
+
+/** Initial retry delay for a transient offscreen measurement failure. */
+const RETRY_BASE_MS = 1000;
+
+/** Retry cap keeps a persistent editor failure from creating a hot loop. */
+const RETRY_MAX_MS = 30_000;
 
 export interface PrewarmCandidate {
   nodeId: string;
@@ -60,6 +73,10 @@ let running = false;
 let stopped = true;
 let rescanHandle: ReturnType<typeof setTimeout> | null = null;
 let unsubscribe: (() => void) | null = null;
+const retryHandles = new Map<string, ReturnType<typeof setTimeout>>();
+const commitCheckHandles = new Map<string, ReturnType<typeof setTimeout>>();
+const commitSettleWaiters = new Map<string, () => void>();
+const failureCounts = new Map<string, number>();
 
 /**
  * Nodes measured this session, keyed by node id + measurement key.
@@ -85,6 +102,15 @@ export function stopHeightPrewarm(): void {
     clearTimeout(rescanHandle);
     rescanHandle = null;
   }
+  for (const handle of retryHandles.values()) clearTimeout(handle);
+  retryHandles.clear();
+  for (const handle of commitCheckHandles.values()) clearTimeout(handle);
+  commitCheckHandles.clear();
+  for (const unsubscribeSettle of commitSettleWaiters.values()) {
+    unsubscribeSettle();
+  }
+  commitSettleWaiters.clear();
+  failureCounts.clear();
   attempted.clear();
 }
 
@@ -115,7 +141,11 @@ async function drain(): Promise<void> {
             markdown: candidate.markdown,
             canvasId,
           });
-          if (stopped || measured.height <= 0) continue;
+          if (stopped) return;
+          if (measured.height <= 0) {
+            scheduleRetry(candidate);
+            continue;
+          }
           // The note was edited while its measurement was in flight, so
           // this height describes content the node no longer has. Drop
           // it; the next scan picks the node up again.
@@ -127,10 +157,12 @@ async function drain(): Promise<void> {
             measuredFor: candidate.measuredFor,
             provisional: measured.provisional,
           });
-        } catch {
-          // A measurement that throws is not worth retrying this
-          // session; the node keeps its existing footprint and
-          // self-measures if the user reaches it.
+          confirmCommit(candidate);
+        } catch (error: unknown) {
+          // Chunk loading and Milkdown mounting can fail transiently. Keeping
+          // the attempt forever would strand an offscreen agent-created note
+          // at the policy minimum for the rest of the app session.
+          scheduleRetry(candidate, error);
         }
       }
       await nextIdle();
@@ -138,6 +170,68 @@ async function drain(): Promise<void> {
   } finally {
     running = false;
   }
+}
+
+function confirmCommit(candidate: PrewarmCandidate): void {
+  const key = attemptKey(candidate.nodeId, candidate.measuredFor);
+  if (commitCheckHandles.has(key) || commitSettleWaiters.has(key)) return;
+  if (isHeightCommitSuspended()) {
+    const unsubscribeSettle = onHeightCommitsSettled(() => {
+      unsubscribeSettle();
+      commitSettleWaiters.delete(key);
+      confirmCommit(candidate);
+    });
+    commitSettleWaiters.set(key, unsubscribeSettle);
+    return;
+  }
+  const handle = setTimeout(() => {
+    commitCheckHandles.delete(key);
+    if (stopped) return;
+    if (isHeightCommitSuspended()) {
+      confirmCommit(candidate);
+      return;
+    }
+    const node = useCanvasStore
+      .getState()
+      .nodes.find((candidateNode) => candidateNode.id === candidate.nodeId);
+    if (!node || resolveHeightMode(node) !== 'auto') {
+      failureCounts.delete(key);
+      return;
+    }
+    const { hint, freshness } = readAutoHeightHint(node);
+    if (
+      freshness === 'current' &&
+      hint?.measuredFor === candidate.measuredFor
+    ) {
+      failureCounts.delete(key);
+      return;
+    }
+    if (autoHeightKey(node) !== candidate.measuredFor) return;
+    scheduleRetry(candidate, new Error('measured height was not committed'));
+  }, COMMIT_CONFIRM_MS);
+  commitCheckHandles.set(key, handle);
+}
+
+function scheduleRetry(candidate: PrewarmCandidate, error?: unknown): void {
+  if (stopped) return;
+  const key = attemptKey(candidate.nodeId, candidate.measuredFor);
+  if (retryHandles.has(key)) return;
+  const failures = (failureCounts.get(key) ?? 0) + 1;
+  failureCounts.set(key, failures);
+  const delay = Math.min(RETRY_BASE_MS * 2 ** (failures - 1), RETRY_MAX_MS);
+  console.warn('[height] offscreen note measurement failed; retrying', {
+    nodeId: candidate.nodeId,
+    measuredFor: candidate.measuredFor,
+    attempt: failures,
+    retryInMs: delay,
+    error,
+  });
+  const handle = setTimeout(() => {
+    retryHandles.delete(key);
+    attempted.delete(key);
+    scheduleRescan();
+  }, delay);
+  retryHandles.set(key, handle);
 }
 
 /**

--- a/apps/web/src/components/Panels/Canvas/Canvas.tsx
+++ b/apps/web/src/components/Panels/Canvas/Canvas.tsx
@@ -52,6 +52,7 @@ import { NoteNode } from '@/components/Nodes/note/NoteNode';
 import { OfficeNode } from '@/components/Nodes/office/OfficeNode';
 import { PDFNode } from '@/components/Nodes/pdf/PDFNode';
 import {
+  cancelHeightCommitSuspensions,
   resumeHeightCommits,
   suspendHeightCommits,
 } from '@/components/Nodes/shared/height/commitSuspension';
@@ -1250,7 +1251,18 @@ export const Canvas: React.FC<CanvasProps> = ({
   }, [rightPanelAnchorNodeId, clearRightPanelAnchor]);
 
   useEffect(() => {
+    const cancelHeightCommits = () => cancelHeightCommitSuspensions();
+    const cancelWhenHidden = () => {
+      if (document.visibilityState === 'hidden') cancelHeightCommits();
+    };
+    window.addEventListener('blur', cancelHeightCommits);
+    window.addEventListener('pointercancel', cancelHeightCommits, true);
+    document.addEventListener('visibilitychange', cancelWhenHidden);
     return () => {
+      window.removeEventListener('blur', cancelHeightCommits);
+      window.removeEventListener('pointercancel', cancelHeightCommits, true);
+      document.removeEventListener('visibilitychange', cancelWhenHidden);
+      cancelHeightCommits();
       rfInstanceRef.current = null;
       setRfInstance(null);
       // If the canvas is torn down mid-drag (route change, canvas
@@ -1515,10 +1527,10 @@ export const Canvas: React.FC<CanvasProps> = ({
           // Pan and zoom both arrive here. A height correction committed
           // mid-gesture would resize a node the user is moving past, so
           // corrections queue up and land once the viewport settles.
-          suspendHeightCommits();
+          suspendHeightCommits('viewport');
         }}
         onMoveEnd={(_event, viewport) => {
-          resumeHeightCommits();
+          resumeHeightCommits('viewport');
           // Mirror pan/zoom into localStorage (per canvas) so browser and
           // desktop restarts restore the same view. Does NOT participate in
           // the structure autosave.

--- a/apps/web/src/store/canvasStore.ts
+++ b/apps/web/src/store/canvasStore.ts
@@ -2432,7 +2432,7 @@ const useCanvasStore = create<RFState>()(
       get().beginGesture('SET_NODE_GEOMETRY');
       // A height correction landing mid-drag would move geometry under
       // the user's hand. Hold them until the gesture settles.
-      suspendHeightCommits();
+      suspendHeightCommits('node-drag');
 
       // Record the pre-drag positions of the dragged nodes so
       // `onNodeDragStop` can tell whether the gesture actually moved
@@ -2459,7 +2459,7 @@ const useCanvasStore = create<RFState>()(
 
     onNodeResizeStart: () => {
       get().beginGesture('SET_NODE_GEOMETRY');
-      suspendHeightCommits();
+      suspendHeightCommits('node-resize');
     },
 
     onNodeDrag: (_event, draggedNode, draggedNodes) => {
@@ -2909,7 +2909,7 @@ const useCanvasStore = create<RFState>()(
     },
 
     onNodeDragStop: (_event, _node, draggedNodes) => {
-      resumeHeightCommits();
+      resumeHeightCommits('node-drag');
       // Cancel any pending preview computation — the drag is over.
       if (_dragPreviewRafId !== null) {
         cancelAnimationFrame(_dragPreviewRafId);

--- a/docs/architecture/node-auto-height.md
+++ b/docs/architecture/node-auto-height.md
@@ -1,7 +1,7 @@
 # Node Auto Height
 
 > Authoritative model for who owns a node's height, how a content height is measured, and how a derived height reaches geometry.
-> Last updated: 2026-07-28
+> Last updated: 2026-08-07
 
 ## 1. Scope and the invariant
 
@@ -76,6 +76,8 @@ Two paths produce an intrinsic height, and both go through the same box and the 
 
 Both resolve under a bounded protocol ([`stability.ts`](../../apps/web/src/components/Nodes/shared/height/measure/stability.ts)): wait for fonts, accept a value only once two consecutive samples agree, resolve _provisionally_ rather than waiting on an undecoded image, and always meet a deadline. A queue that cannot drain is worse than a wrong number. A provisional hint reads as `stale` on the next load, so it is never trusted indefinitely.
 
+An offscreen editor build or measurement failure emits a `[height] offscreen note measurement failed; retrying` console warning with the node id, measurement key, attempt number, retry delay, and original error, then retries with capped exponential backoff. The singleton host clears a rejected build promise before the retry, so one transient chunk-load or Milkdown mount failure cannot strand every later agent-created note at the policy minimum for the rest of the app session. A successful measurement is not considered complete until the live node carries its current hint; if a proposal is silently dropped before that write, prewarming uses the same backoff path instead of suppressing that node for the rest of the session. The confirmation window starts only after interaction suspension settles, so a legitimately held proposal is never reported or re-measured as a failure.
+
 Measurement reads `.ProseMirror` rather than the host, whose `scrollHeight` Crepe's absolutely positioned block handle inflates. `.ProseMirror` is `display: flow-root` so a leading child's margin cannot collapse out of the box being measured.
 
 ## 7. Commit gating
@@ -83,7 +85,7 @@ Measurement reads `.ProseMirror` rather than the host, whose `scrollHeight` Crep
 Proposals go to a singleton queue ([`commitQueue.ts`](../../apps/web/src/components/Nodes/shared/height/commitQueue.ts)) with two gates, both evaluated **at flush time against the live store** — a proposal held through a gesture routinely describes a node the user has since pinned, resized, or deleted.
 
 1. **No-op suppression.** Discard when the proposal resolves to the height the node already has _and_ the stored hint already carries the proposal's key. The comparison is exact, because quantization has already collapsed anything smaller than one step. The provenance half is not optional: content that changes without changing its height would otherwise leave the hint pointing at old content and be re-measured on every load forever.
-2. **Interaction suspension.** Pan, zoom, node drag, and resize hold commits until they settle. The ref-counted counter lives in its own dependency-free module ([`commitSuspension.ts`](../../apps/web/src/components/Nodes/shared/height/commitSuspension.ts)) because the gesture handlers live in `canvasStore` and the queue reads `canvasStore`.
+2. **Interaction suspension.** Pan, zoom, node drag, and resize hold commits until they settle. Real interactions use named, idempotent holds, so duplicate start notifications cannot leak a counter. The normal end event releases its hold; `pointercancel`, window blur, document hiding, and Canvas unmount explicitly cancel named holds when React Flow cannot deliver an end event. No elapsed-time heuristic releases an active gesture, so a user may pause while holding the pointer without geometry changing underneath it. The hold state lives in its own dependency-free module ([`commitSuspension.ts`](../../apps/web/src/components/Nodes/shared/height/commitSuspension.ts)) because the gesture handlers live in `canvasStore` and the queue reads `canvasStore`.
 
 Proposals are keyed by node, so a burst collapses to one command and therefore one end-of-batch frame refit.
 
@@ -129,22 +131,22 @@ Unit tests cannot cover this class: the failures live in CSS layout, and happy-d
 
 ## Code entry points
 
-| File                                                                                                                          | Responsibility                                                                         |
-| ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| [`height/policy.ts`](../../packages/shared/src/canvas-engine/height/policy.ts)                                                | Per-type policy, node shell inset, `resolveHeightMode` — the only ownership judgement. |
-| [`height/compute.ts`](../../packages/shared/src/canvas-engine/height/compute.ts)                                              | `contentScaleFor`, `intrinsicToLayoutHeight`, quantization.                            |
-| [`height/freshness.ts`](../../packages/shared/src/canvas-engine/height/freshness.ts)                                          | `AutoHeightKey`, `HEIGHT_LAYOUT_VERSION`, `readAutoHeightHint`.                        |
-| [`height/materialize.ts`](../../packages/shared/src/canvas-engine/height/materialize.ts)                                      | Hint → `style.height`; shared by web load and headless hydration.                      |
-| [`commands/setNodeGeometry.ts`](../../packages/shared/src/canvas-engine/commands/setNodeGeometry.ts)                          | Authored geometry; the `'auto'` branch.                                                |
-| [`commands/applyMeasuredHeight.ts`](../../packages/shared/src/canvas-engine/commands/applyMeasuredHeight.ts)                  | Derived correction; non-undoable; collects frame ancestors.                            |
-| [`commands/changeNodeType.ts`](../../packages/shared/src/canvas-engine/commands/changeNodeType.ts)                            | Drops the hint on conversion and records the target type's ownership.                  |
-| [`note/noteContentHost.ts`](../../apps/web/src/components/Nodes/note/noteContentHost.ts)                                      | The box and the reader shared by the mounted note and the offscreen measurer.          |
-| [`note/NoteNode.tsx`](../../apps/web/src/components/Nodes/note/NoteNode.tsx)                                                  | Renders from `style.height`; reports an intrinsic height; never sizes itself.          |
-| [`note/heightMemory.ts`](../../apps/web/src/components/Nodes/note/heightMemory.ts)                                            | Session-scoped remembered pinned height; gated on ownership, not on numericness.       |
-| [`shared/height/commitQueue.ts`](../../apps/web/src/components/Nodes/shared/height/commitQueue.ts)                            | No-op suppression, coalescing, flush-time validation.                                  |
-| [`shared/height/commitSuspension.ts`](../../apps/web/src/components/Nodes/shared/height/commitSuspension.ts)                  | Ref-counted interaction hold; kept dependency-free to stay acyclic with the store.     |
-| [`shared/height/measure/`](../../apps/web/src/components/Nodes/shared/height/measure/offscreenMeasurer.ts)                    | Offscreen singleton measurer, stability protocol, viewport-priority prewarm queue.     |
-| [`canvasStore/load/normalizeNodeHeights.ts`](../../apps/web/src/store/canvasStore/load/normalizeNodeHeights.ts)               | Load-time ownership normalization and materialization.                                 |
-| [`canvasStore/load/warmupNodeHeights.ts`](../../apps/web/src/store/canvasStore/load/warmupNodeHeights.ts)                     | Bounded pre-paint measurement of never-measured notes.                                 |
-| [`canvasStore/height/measureMissingAutoHeights.ts`](../../apps/web/src/store/canvasStore/height/measureMissingAutoHeights.ts) | On-demand measurement behind a fixed → auto toggle.                                    |
-| [`hooks/useNodeScale.ts`](../../apps/web/src/hooks/useNodeScale.ts)                                                           | Content scale; delegates to `contentScaleFor` so one formula exists.                   |
+| File                                                                                                                          | Responsibility                                                                                           |
+| ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| [`height/policy.ts`](../../packages/shared/src/canvas-engine/height/policy.ts)                                                | Per-type policy, node shell inset, `resolveHeightMode` — the only ownership judgement.                   |
+| [`height/compute.ts`](../../packages/shared/src/canvas-engine/height/compute.ts)                                              | `contentScaleFor`, `intrinsicToLayoutHeight`, quantization.                                              |
+| [`height/freshness.ts`](../../packages/shared/src/canvas-engine/height/freshness.ts)                                          | `AutoHeightKey`, `HEIGHT_LAYOUT_VERSION`, `readAutoHeightHint`.                                          |
+| [`height/materialize.ts`](../../packages/shared/src/canvas-engine/height/materialize.ts)                                      | Hint → `style.height`; shared by web load and headless hydration.                                        |
+| [`commands/setNodeGeometry.ts`](../../packages/shared/src/canvas-engine/commands/setNodeGeometry.ts)                          | Authored geometry; the `'auto'` branch.                                                                  |
+| [`commands/applyMeasuredHeight.ts`](../../packages/shared/src/canvas-engine/commands/applyMeasuredHeight.ts)                  | Derived correction; non-undoable; collects frame ancestors.                                              |
+| [`commands/changeNodeType.ts`](../../packages/shared/src/canvas-engine/commands/changeNodeType.ts)                            | Drops the hint on conversion and records the target type's ownership.                                    |
+| [`note/noteContentHost.ts`](../../apps/web/src/components/Nodes/note/noteContentHost.ts)                                      | The box and the reader shared by the mounted note and the offscreen measurer.                            |
+| [`note/NoteNode.tsx`](../../apps/web/src/components/Nodes/note/NoteNode.tsx)                                                  | Renders from `style.height`; reports an intrinsic height; never sizes itself.                            |
+| [`note/heightMemory.ts`](../../apps/web/src/components/Nodes/note/heightMemory.ts)                                            | Session-scoped remembered pinned height; gated on ownership, not on numericness.                         |
+| [`shared/height/commitQueue.ts`](../../apps/web/src/components/Nodes/shared/height/commitQueue.ts)                            | No-op suppression, coalescing, flush-time validation.                                                    |
+| [`shared/height/commitSuspension.ts`](../../apps/web/src/components/Nodes/shared/height/commitSuspension.ts)                  | Named interaction holds with explicit cancellation; kept dependency-free to stay acyclic with the store. |
+| [`shared/height/measure/`](../../apps/web/src/components/Nodes/shared/height/measure/offscreenMeasurer.ts)                    | Offscreen singleton measurer, stability protocol, viewport-priority prewarm queue.                       |
+| [`canvasStore/load/normalizeNodeHeights.ts`](../../apps/web/src/store/canvasStore/load/normalizeNodeHeights.ts)               | Load-time ownership normalization and materialization.                                                   |
+| [`canvasStore/load/warmupNodeHeights.ts`](../../apps/web/src/store/canvasStore/load/warmupNodeHeights.ts)                     | Bounded pre-paint measurement of never-measured notes.                                                   |
+| [`canvasStore/height/measureMissingAutoHeights.ts`](../../apps/web/src/store/canvasStore/height/measureMissingAutoHeights.ts) | On-demand measurement behind a fixed → auto toggle.                                                      |
+| [`hooks/useNodeScale.ts`](../../apps/web/src/hooks/useNodeScale.ts)                                                           | Content scale; delegates to `contentScaleFor` so one formula exists.                                     |


### PR DESCRIPTION
## Summary

Fix auto-height notes that remain at their initial minimum height after agent creation, paste, or mounted editing.

- Replace the leak-prone anonymous gesture counter with named, idempotent holds for viewport movement, node drag, and resize.
- Release abandoned holds only on explicit cancellation signals (`pointercancel`, window blur, document hiding, and Canvas unmount), without an inactivity watchdog that could fire during a valid paused gesture.
- Recover the offscreen Milkdown singleton after transient build failures and retry failed or uncommitted measurements with capped exponential backoff.
- Start commit confirmation only after interaction suspension settles, avoiding false failures during legitimate gestures.
- Add browser coverage for agent-created notes, structured frames, and manually edited mounted notes; update the auto-height architecture reference.

## Validation

- `pnpm --filter @huabu/web exec vitest run src/components/Nodes/shared/height/__tests__/commitQueue.test.ts src/components/Nodes/shared/height/measure/__tests__/prewarmQueue.test.ts` (27 tests)
- `pnpm --filter @huabu/web exec playwright test e2e/note-auto-height.spec.ts --grep "agent-created|manually pasted"` (3 tests)
- `pnpm --filter @huabu/web typecheck`
- Targeted ESLint and Prettier checks
- `node scripts/check-headers.mjs`
- `git diff --check`