### PR TITLE
fix(web): resolve visual-review accessibility gaps

### DIFF
--- a/apps/web/src/components/Common/Button.tsx
+++ b/apps/web/src/components/Common/Button.tsx
@@ -103,7 +103,7 @@ const iconSizeClasses: Record<NonNullable<ButtonProps['size']>, string> = {
 };
 
 const iconOnlySizeClasses: Record<NonNullable<ButtonProps['size']>, string> = {
-  sm: 'p-1',
+  sm: 'min-h-6 min-w-6 p-1',
   md: 'p-1.5',
   lg: 'p-2',
 };

--- a/apps/web/src/components/Common/FloatingToolbar.test.tsx
+++ b/apps/web/src/components/Common/FloatingToolbar.test.tsx
@@ -3,7 +3,7 @@
 
 import { createRoot, type Root } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { FloatingToolbar } from './FloatingToolbar';
 
@@ -68,5 +68,53 @@ describe('FloatingToolbar.ColorPicker', () => {
     });
 
     expect(picked).toEqual(['red']);
+  });
+});
+
+describe('FloatingToolbar.SizePicker', () => {
+  it('renders auto height as static text with a 24px mode target', () => {
+    const onToggle = vi.fn();
+    const container = render(
+      <FloatingToolbar.SizePicker
+        width={320}
+        height={180}
+        onApply={vi.fn()}
+        autoSize={{ active: true, onToggle }}
+      />,
+    );
+
+    expect(container.querySelector('input[aria-label="Height"]')).toBeNull();
+
+    const autoValue = container.querySelector('span.text-fg-muted.italic');
+    expect(autoValue?.tagName).toBe('SPAN');
+    expect(autoValue?.classList.contains('h-6')).toBe(true);
+    expect(autoValue?.classList.contains('text-fg-subtle')).toBe(false);
+
+    const toggle = container.querySelector('button');
+    expect(toggle?.classList.contains('h-6')).toBe(true);
+    expect(toggle?.classList.contains('w-6')).toBe(true);
+
+    act(() => toggle?.click());
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+
+  it('keeps fixed height editable with a 24px input target', () => {
+    const container = render(
+      <FloatingToolbar.SizePicker
+        width={320}
+        height={180}
+        onApply={vi.fn()}
+        autoSize={{ active: false, onToggle: vi.fn() }}
+      />,
+    );
+
+    const heightInput = container.querySelector('input[aria-label="Height"]');
+    const widthInput = container.querySelector('input[aria-label="Width"]');
+    expect(widthInput?.getAttribute('name')).toBe('node-width');
+    expect(heightInput?.getAttribute('name')).toBe('node-height');
+    expect(heightInput?.classList.contains('h-6')).toBe(true);
+    expect(container.querySelector('button')?.classList.contains('h-6')).toBe(
+      true,
+    );
   });
 });

--- a/apps/web/src/components/Common/FloatingToolbar.tsx
+++ b/apps/web/src/components/Common/FloatingToolbar.tsx
@@ -457,18 +457,19 @@ interface ToolbarSizePickerProps {
 }
 
 const SIZE_INPUT_CLASS =
-  'nodrag w-10 bg-transparent text-xs outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none';
+  'nodrag h-6 w-10 bg-transparent text-xs outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none';
 
 // Rounded filled "capsule" wrapping the label + input so `W 937`
 // reads as one solid chip (more cohesive than a hairline-bordered
 // field). Frame hug wraps its W/H pair in a single shared capsule
 // instead, so those inner inputs opt out via `unstyled`.
 const SIZE_CAPSULE_CLASS =
-  'bg-bg-default hover:bg-hover focus-within:ring-info rounded-md px-1.5 py-1 transition-colors focus-within:ring-1';
+  'bg-bg-default hover:bg-hover focus-within:ring-info rounded-md px-1.5 py-0 transition-colors focus-within:ring-1';
 
 interface ToolbarNumberInputProps {
   label: string;
   ariaLabel: string;
+  name: string;
   value: number | null;
   onApply: (value: number) => void;
   min?: number;
@@ -500,6 +501,7 @@ interface ToolbarNumberInputProps {
 function ToolbarNumberInput({
   label,
   ariaLabel,
+  name,
   value,
   onApply,
   min = 1,
@@ -513,6 +515,7 @@ function ToolbarNumberInput({
   unstyled = false,
 }: ToolbarNumberInputProps) {
   const isAuto = typeof autoText === 'string';
+  const Container: 'div' | 'label' = isAuto ? 'div' : 'label';
   const [text, setText] = useState('');
 
   useEffect(() => {
@@ -550,7 +553,7 @@ function ToolbarNumberInput({
   };
 
   return (
-    <label
+    <Container
       className={cn(
         'nodrag flex items-center gap-1',
         !unstyled && SIZE_CAPSULE_CLASS,
@@ -561,46 +564,55 @@ function ToolbarNumberInput({
         {label}
       </span>
       <div className="relative flex items-center">
-        <input
-          type={isAuto ? 'text' : 'number'}
-          inputMode={isAuto ? undefined : 'numeric'}
-          aria-label={ariaLabel}
-          min={isAuto ? undefined : min}
-          max={isAuto ? undefined : max}
-          step={isAuto ? undefined : step}
-          disabled={disabled}
-          readOnly={isAuto}
-          value={isAuto ? autoText : text}
-          placeholder={isAuto || typeof value === 'number' ? '' : '—'}
-          onChange={isAuto ? undefined : (e) => setText(e.target.value)}
-          onBlur={isAuto ? undefined : commit}
-          onMouseDown={(e) => e.stopPropagation()}
-          onKeyDown={(e) => {
-            e.stopPropagation();
-            if (isAuto) return;
-            if (e.key === 'Enter') {
-              commit();
-              (e.target as HTMLInputElement).blur();
-            } else if (e.key === 'Escape') {
-              restore();
-              (e.target as HTMLInputElement).blur();
-            }
-          }}
-          className={cn(
-            SIZE_INPUT_CLASS,
-            endAdornment && 'w-14 pr-5',
-            isAuto && 'cursor-default',
-            disabled && 'cursor-not-allowed opacity-50',
-            inputClassName,
-          )}
-        />
+        {isAuto ? (
+          <span
+            className={cn(
+              'nodrag inline-flex h-6 w-10 items-center bg-transparent text-xs',
+              endAdornment && 'w-9',
+              inputClassName,
+            )}
+          >
+            <span className="sr-only">{ariaLabel}: </span>
+            {autoText}
+          </span>
+        ) : (
+          <input
+            type="number"
+            name={name}
+            inputMode="numeric"
+            aria-label={ariaLabel}
+            min={min}
+            max={max}
+            step={step}
+            disabled={disabled}
+            value={text}
+            placeholder={typeof value === 'number' ? '' : '—'}
+            onChange={(e) => setText(e.target.value)}
+            onBlur={commit}
+            onMouseDown={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              e.stopPropagation();
+              if (e.key === 'Enter') {
+                commit();
+                (e.target as HTMLInputElement).blur();
+              } else if (e.key === 'Escape') {
+                restore();
+                (e.target as HTMLInputElement).blur();
+              }
+            }}
+            className={cn(
+              SIZE_INPUT_CLASS,
+              endAdornment && 'w-9',
+              disabled && 'cursor-not-allowed opacity-50',
+              inputClassName,
+            )}
+          />
+        )}
         {endAdornment && (
-          <div className="absolute right-1 flex items-center">
-            {endAdornment}
-          </div>
+          <div className="flex items-center">{endAdornment}</div>
         )}
       </div>
-    </label>
+    </Container>
   );
 }
 
@@ -675,7 +687,7 @@ function ToolbarSizePicker({
             auto.onToggle();
           }}
           className={cn(
-            'nodrag flex h-4 w-4 items-center justify-center rounded transition-colors',
+            'nodrag flex h-6 w-6 items-center justify-center rounded transition-colors',
             autoActive ? 'text-info' : 'text-fg-subtle hover:text-fg-default',
           )}
         >
@@ -689,11 +701,12 @@ function ToolbarSizePicker({
     <ToolbarNumberInput
       label="W"
       ariaLabel="Width"
+      name="node-width"
       value={width}
       min={minSize}
       unstyled={isBothAxes}
       autoText={widthIsAuto ? autoLabel : undefined}
-      inputClassName={widthIsAuto ? 'text-fg-subtle italic' : undefined}
+      inputClassName={widthIsAuto ? 'text-fg-muted italic' : undefined}
       onApply={(next) => {
         if (
           widthIsAuto ||
@@ -710,11 +723,12 @@ function ToolbarSizePicker({
     <ToolbarNumberInput
       label="H"
       ariaLabel="Height"
+      name="node-height"
       value={height}
       min={minSize}
       unstyled={isBothAxes}
       autoText={heightIsAuto ? autoLabel : undefined}
-      inputClassName={heightIsAuto ? 'text-fg-subtle italic' : undefined}
+      inputClassName={heightIsAuto ? 'text-fg-muted italic' : undefined}
       endAdornment={
         isBothAxes ? undefined : modeToggle(<UnfoldVertical size={12} />)
       }

--- a/apps/web/src/components/Common/SplitSelect.test.tsx
+++ b/apps/web/src/components/Common/SplitSelect.test.tsx
@@ -44,4 +44,28 @@ describe('SplitSelect', () => {
     act(() => buttons[0].click());
     expect(onPrimaryAction).toHaveBeenCalledWith('lasso');
   });
+
+  it('names both icon-only controls without relying on tooltip markup', () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() =>
+      root?.render(
+        <SplitSelect
+          options={[{ value: 'select', label: 'Select' }]}
+          value="select"
+          onChange={vi.fn()}
+          onPrimaryAction={vi.fn()}
+          iconOnly
+          primaryTitle="Select tool"
+          menuTitle="More tools"
+        />,
+      ),
+    );
+
+    const buttons = container.querySelectorAll('button');
+    expect(buttons[0].getAttribute('aria-label')).toBe('Select tool');
+    expect(buttons[1].getAttribute('aria-label')).toBe('More tools');
+  });
 });

--- a/apps/web/src/components/Common/SplitSelect.tsx
+++ b/apps/web/src/components/Common/SplitSelect.tsx
@@ -168,6 +168,14 @@ export function SplitSelect<T extends string = string>({
           disabled={disabled}
           onClick={handlePrimaryAction}
           title={primaryTitle}
+          aria-label={
+            iconOnly
+              ? (primaryTitle ??
+                current?.buttonLabel ??
+                current?.label ??
+                placeholder)
+              : undefined
+          }
           shortcutBadge={primaryShortcutBadge}
           shortcutBadgeActive={primaryShortcutBadgeActive}
           className={cn(
@@ -192,6 +200,7 @@ export function SplitSelect<T extends string = string>({
             disabled={disabled}
             onClick={handleToggle}
             title={menuTitle}
+            aria-label={menuTitle ?? `${current?.label ?? placeholder} options`}
             aria-expanded={isOpen}
             aria-haspopup="listbox"
             className={cn(

--- a/apps/web/src/components/Milkdown/MilkdownPreview.tsx
+++ b/apps/web/src/components/Milkdown/MilkdownPreview.tsx
@@ -21,6 +21,7 @@
  */
 
 import { useCallback, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { resolveArtifactUrl } from '@/api/artifact';
 
@@ -32,6 +33,8 @@ import type { MilkdownBlockDragEvent } from './types';
 export interface MilkdownPreviewProps {
   markdown: string;
   className?: string;
+  /** Accessible name for the rendered read-only rich-text surface. */
+  ariaLabel?: string;
   /**
    * Canvas id used to resolve artifact-key image `src`s (e.g.
    * `art_abc.png`) into fetchable URLs for the rendered `<img>`. When
@@ -88,13 +91,16 @@ function shouldSwallowKey(e: React.KeyboardEvent): boolean {
 export function MilkdownPreview(
   props: MilkdownPreviewProps,
 ): React.JSX.Element {
+  const { t } = useTranslation();
   const {
     markdown,
     className,
+    ariaLabel,
     canvasId,
     enableBlockDrag = false,
     onBlockDragStart,
   } = props;
+  const resolvedAriaLabel = ariaLabel ?? t('editor.readOnlyContent');
 
   const containerRef = useRef<HTMLDivElement>(null);
   const instanceRef = useRef<MilkdownInstance | null>(null);
@@ -107,6 +113,8 @@ export function MilkdownPreview(
   /** Track latest canvasId so the mount-only editor reads a fresh value. */
   const canvasIdRef = useRef(canvasId);
   canvasIdRef.current = canvasId;
+  const ariaLabelRef = useRef(resolvedAriaLabel);
+  ariaLabelRef.current = resolvedAriaLabel;
 
   useEffect(() => {
     let cancelled = false;
@@ -140,6 +148,7 @@ export function MilkdownPreview(
         // initiate a native drag. Input mutations are still blocked by
         // the wrapper's capture handlers below.
         editable: enableBlockDrag,
+        ariaLabel: ariaLabelRef.current,
         // Disable Crepe's edit-time chrome (Toolbar / LinkTooltip /
         // Table reorder handles) when the surface is drag-only. See
         // `MilkdownFactoryOptions.previewMode`.
@@ -156,6 +165,7 @@ export function MilkdownPreview(
         return;
       }
 
+      instance.setAriaLabel(ariaLabelRef.current);
       instanceRef.current = instance;
 
       const pending = pendingMarkdownRef.current;
@@ -188,6 +198,13 @@ export function MilkdownPreview(
     lastSyncedRef.current = next;
     instance.setMarkdown(next);
   }, [markdown]);
+
+  // The editor mounts asynchronously, so the mount path above applies the
+  // initial name. Keep the live textbox in sync when the caller overrides
+  // the label or the active language changes without remounting Milkdown.
+  useEffect(() => {
+    instanceRef.current?.setAriaLabel(resolvedAriaLabel);
+  }, [resolvedAriaLabel]);
 
   // ---- Capture handlers that suppress editing when in drag-only mode ----
   // Installed on the host div so they intercept input verbs before

--- a/apps/web/src/components/Milkdown/__tests__/previewAccessibility.test.tsx
+++ b/apps/web/src/components/Milkdown/__tests__/previewAccessibility.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+
+import { StrictMode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { i18n } from '@/i18n';
+
+import { MilkdownPreview } from '../MilkdownPreview';
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe('MilkdownPreview accessibility', () => {
+  it('names the textbox through StrictMode replacement and updates an override', async () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root?.render(
+        <StrictMode>
+          <MilkdownPreview markdown="Storage survives reload." />
+        </StrictMode>,
+      );
+    });
+
+    await vi.waitFor(() => {
+      const textbox = container?.querySelector('.ProseMirror[role="textbox"]');
+      expect(textbox?.getAttribute('aria-label')).toBe(
+        i18n.t('editor.readOnlyContent'),
+      );
+    });
+
+    act(() => {
+      root?.render(
+        <StrictMode>
+          <MilkdownPreview
+            markdown="Storage survives reload."
+            ariaLabel="Stored note preview"
+          />
+        </StrictMode>,
+      );
+    });
+
+    await vi.waitFor(() => {
+      const textbox = container?.querySelector('.ProseMirror[role="textbox"]');
+      expect(textbox?.getAttribute('aria-label')).toBe('Stored note preview');
+    });
+  });
+});

--- a/apps/web/src/components/Milkdown/__tests__/previewAccessibility.test.tsx
+++ b/apps/web/src/components/Milkdown/__tests__/previewAccessibility.test.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 // @vitest-environment happy-dom
 
 import { StrictMode } from 'react';

--- a/apps/web/src/components/Milkdown/__tests__/previewChrome.test.ts
+++ b/apps/web/src/components/Milkdown/__tests__/previewChrome.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createMilkdown, type MilkdownInstance } from '../createMilkdown';
+
+let instance: MilkdownInstance | undefined;
+let root: HTMLDivElement | undefined;
+
+afterEach(async () => {
+  await instance?.destroy();
+  root?.remove();
+  instance = undefined;
+  root = undefined;
+});
+
+describe('Milkdown read-only chrome', () => {
+  it('omits link-edit controls without dropping table rendering', async () => {
+    root = document.createElement('div');
+    document.body.appendChild(root);
+
+    instance = await createMilkdown({
+      root,
+      initialMarkdown: `A [link](https://example.com).
+
+| A | B |
+| --- | --- |
+| hello | world |`,
+      editable: false,
+      toolbarMode: 'none',
+    });
+
+    expect(root.querySelector('input.input-area')).toBeNull();
+    expect(root.querySelector('.milkdown-table-block')).not.toBeNull();
+    expect(instance.getMarkdown()).toContain('[link](https://example.com)');
+  });
+});

--- a/apps/web/src/components/Milkdown/__tests__/previewChrome.test.ts
+++ b/apps/web/src/components/Milkdown/__tests__/previewChrome.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it } from 'vitest';

--- a/apps/web/src/components/Milkdown/createMilkdown.ts
+++ b/apps/web/src/components/Milkdown/createMilkdown.ts
@@ -14,6 +14,7 @@
 
 import {
   editorViewCtx,
+  editorViewOptionsCtx,
   parserCtx,
   schemaCtx,
   serializerCtx,
@@ -172,6 +173,8 @@ export interface MilkdownFactoryOptions {
   editable?: boolean;
   /** Optional placeholder text shown when the doc is empty. */
   placeholder?: string;
+  /** Accessible name applied to the ProseMirror textbox. */
+  ariaLabel?: string;
   /** Which selection toolbar surface should be active. Default `huabu`. */
   toolbarMode?: 'none' | 'huabu';
   /**
@@ -283,6 +286,8 @@ export interface MilkdownInstance {
   setMarkdown(markdown: string): void;
   /** Toggle the editor between editable and read-only. */
   setReadonly(readonly: boolean): void;
+  /** Update the ProseMirror textbox's accessible name. */
+  setAriaLabel(label: string): void;
   /** Current block, inline mark, and color state for toolbar rendering. */
   getFormattingState(): MilkdownFormattingState;
   /** Subscribe to formatting-state changes after editor transactions. */
@@ -1751,6 +1756,7 @@ export async function createMilkdown(
     initialMarkdown,
     editable = true,
     placeholder,
+    ariaLabel: initialAriaLabel,
     toolbarMode = 'huabu',
     previewMode = false,
     uploadImage,
@@ -1758,6 +1764,7 @@ export async function createMilkdown(
   } = options;
   const resolveImageSrc = options.resolveImageSrc ?? ((src: string) => src);
   const useReactToolbar = !previewMode && toolbarMode === 'huabu';
+  let ariaLabel = initialAriaLabel;
 
   // Normalize LaTeX-style math delimiters (`\[…\]`, `\(…\)`)
   // emitted by AI assistants into the `$$…$$` / `$…$` form that
@@ -1774,11 +1781,11 @@ export async function createMilkdown(
       [Crepe.Feature.AI]: false,
       [Crepe.Feature.TopBar]: false,
       [Crepe.Feature.Toolbar]: false,
-      // Hide Crepe edit-time popovers when React owns the toolbar, and
-      // in preview mode. BlockEdit stays on so the drag handle is still
-      // rendered; the slash menu inside BlockEdit is naturally suppressed
-      // in preview because input events never reach the editor (see
-      // `MilkdownPreview` capture handlers).
+      // Hide Crepe edit-time popovers when React owns the toolbar, when
+      // the editor is read-only, and in drag-only preview mode. BlockEdit
+      // stays on so the drag handle is still rendered; the slash menu inside
+      // BlockEdit is naturally suppressed in preview because input events
+      // never reach the editor (see `MilkdownPreview` capture handlers).
       //
       // `Cursor` is also disabled in preview mode: it injects a
       // permanent `<div class="crepe-drop-cursor milkdown-drop-indicator">`
@@ -1787,7 +1794,7 @@ export async function createMilkdown(
       // never receive typing input, so both are dead weight — and with
       // N message cards in a long thread we'd otherwise leak N hidden
       // overlay divs into the DOM.
-      ...(useReactToolbar || previewMode
+      ...(useReactToolbar || previewMode || !editable
         ? {
             [Crepe.Feature.LinkTooltip]: false,
           }
@@ -1804,6 +1811,26 @@ export async function createMilkdown(
         ? { [Crepe.Feature.Placeholder]: { text: placeholder } }
         : {}),
     },
+  });
+
+  // ProseMirror owns the textbox DOM and can replace it during Crepe's async
+  // setup (notably across React StrictMode's setup/cleanup replay). Put the
+  // accessible name in the EditorView props so every DOM instance is born
+  // with it instead of patching whichever `.ProseMirror` happens to be
+  // mounted at one point in time.
+  crepe.editor.config((ctx) => {
+    ctx.update(editorViewOptionsCtx, (viewOptions) => {
+      const inheritedAttributes = viewOptions.attributes;
+      return {
+        ...viewOptions,
+        attributes: (state) => ({
+          ...(typeof inheritedAttributes === 'function'
+            ? inheritedAttributes(state)
+            : inheritedAttributes),
+          ...(ariaLabel ? { 'aria-label': ariaLabel } : {}),
+        }),
+      };
+    });
   });
 
   // Markdown change listeners.
@@ -2362,6 +2389,15 @@ export async function createMilkdown(
     },
     setReadonly: (readonly: boolean) => {
       crepe.setReadonly(readonly);
+    },
+    setAriaLabel: (label: string) => {
+      ariaLabel = label;
+      crepe.editor.action((ctx) => {
+        const view = ctx.get(editorViewCtx);
+        // Re-applying the declarative attributes prop makes ProseMirror
+        // recompute its outer decoration from the updated closure value.
+        view.setProps({ attributes: view.props.attributes });
+      });
     },
     getFormattingState: () => {
       let result: MilkdownFormattingState = {

--- a/apps/web/src/components/Panels/Canvas/Canvas.tsx
+++ b/apps/web/src/components/Panels/Canvas/Canvas.tsx
@@ -344,7 +344,7 @@ const CanvasZoomLevel: React.FC = () => {
     <ControlButton
       className="w-6.5! p-0! text-[10px]! leading-none font-medium! tabular-nums"
       title={t('canvasControls.resetZoom')}
-      aria-label={t('canvasControls.zoomAria', { percentage })}
+      aria-label={`${multiplier}×. ${t('canvasControls.zoomAria', { percentage })}`}
       onClick={() => void zoomTo(1, { duration: 200 })}
     >
       {multiplier}×

--- a/apps/web/src/components/Panels/Canvas/CanvasToolbar.tsx
+++ b/apps/web/src/components/Panels/Canvas/CanvasToolbar.tsx
@@ -718,6 +718,9 @@ export const NodeToolbar = ({ activeTool, onToolChange }: NodeToolbarProps) => {
       >
         <div className="mt-4 flex flex-col gap-0">
           <textarea
+            name="resource-urls"
+            autoComplete="off"
+            aria-label={t('toolbar.resources.linkDescription')}
             className="border-edge-default placeholder:text-fg-subtle focus:border-info focus:ring-info min-h-25 w-full resize-none rounded-md border bg-transparent px-3 py-2 text-sm focus:outline-none"
             placeholder={`https://example.com/image.png\nhttps://example.com/doc.pdf\nhttps://google.com`}
             value={linkText}

--- a/apps/web/src/components/Panels/Canvas/FloatingToolbars/MultiSelectToolbar.tsx
+++ b/apps/web/src/components/Panels/Canvas/FloatingToolbars/MultiSelectToolbar.tsx
@@ -342,6 +342,7 @@ export const MultiSelectToolbar = () => {
         <FloatingToolbar.NumberInput
           label="Font"
           ariaLabel="Font size"
+          name="font-size"
           value={textFlowSelection.fontSize}
           min={8}
           max={160}

--- a/apps/web/src/components/Panels/Canvas/FloatingToolbars/NodeFloatingToolbar.tsx
+++ b/apps/web/src/components/Panels/Canvas/FloatingToolbars/NodeFloatingToolbar.tsx
@@ -364,6 +364,7 @@ export const NodeFloatingToolbar = memo(
           <FloatingToolbar.NumberInput
             label="Font"
             ariaLabel="Font size"
+            name="font-size"
             value={data.style?.fontSize ?? 16}
             min={8}
             max={160}

--- a/apps/web/src/components/Panels/ChatPanel/ChatInput.tsx
+++ b/apps/web/src/components/Panels/ChatPanel/ChatInput.tsx
@@ -596,6 +596,9 @@ export const ChatInput = ({
           <div className="relative">
             <textarea
               ref={textareaRef}
+              name="agent-message"
+              autoComplete="off"
+              aria-label={currentPlaceholder}
               value={value}
               onChange={(e) => {
                 onChange(e.target.value);

--- a/apps/web/src/components/Panels/ChatPanel/NewChatMenu.test.tsx
+++ b/apps/web/src/components/Panels/ChatPanel/NewChatMenu.test.tsx
@@ -1,0 +1,51 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { NewChatMenu } from './NewChatMenu';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      key === 'chat.startChatWith' ? 'Start chat with…' : key,
+  }),
+}));
+
+vi.mock('./agentMenu', () => ({
+  AgentMenuOptions: () => null,
+  useAddAgentEditor: () => ({ openEditor: vi.fn(), editor: null }),
+}));
+
+let root: Root | undefined;
+let container: HTMLDivElement | undefined;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = undefined;
+  container = undefined;
+});
+
+describe('NewChatMenu', () => {
+  it('keeps the menu trigger at least 24px wide', () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root?.render(
+        <NewChatMenu
+          currentMode="ask"
+          currentBinding={{ kind: 'internal' }}
+          profiles={[]}
+          onSelect={vi.fn()}
+        />,
+      );
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Start chat with…"]',
+    );
+    expect(trigger?.classList.contains('min-w-6')).toBe(true);
+  });
+});

--- a/apps/web/src/components/Panels/ChatPanel/NewChatMenu.test.tsx
+++ b/apps/web/src/components/Panels/ChatPanel/NewChatMenu.test.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';

--- a/apps/web/src/components/Panels/ChatPanel/NewChatMenu.tsx
+++ b/apps/web/src/components/Panels/ChatPanel/NewChatMenu.tsx
@@ -153,7 +153,7 @@ export const NewChatMenu = ({
           title={t('chat.startChatWith')}
           tooltipPlacement="bottom"
           className={cn(
-            'rounded-l-none px-0.5 [&_svg]:h-3 [&_svg]:w-3',
+            'min-w-6 rounded-l-none px-0.5 [&_svg]:h-3 [&_svg]:w-3',
             isOpen && 'bg-bg-default',
           )}
         >

--- a/apps/web/src/components/Panels/Header/AppMenu.test.tsx
+++ b/apps/web/src/components/Panels/Header/AppMenu.test.tsx
@@ -1,0 +1,93 @@
+import { act, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AppMenu } from './AppMenu';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useLocation: () => ({ pathname: '/canvas/c1' }),
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('../../../config/handbook', () => ({ openUserHandbook: vi.fn() }));
+vi.mock('../../../config/shortcuts', () => ({
+  getShortcutKeys: () => undefined,
+}));
+vi.mock('../../../hooks/useAppUpdate', () => ({
+  canCheckForUpdates: () => true,
+  useAppUpdate: () => ({ status: { state: 'idle' }, check: vi.fn() }),
+}));
+vi.mock('../../../hooks/useCanvasActions', () => ({
+  useCanvasActions: () => ({
+    create: vi.fn(),
+    openImportDialog: vi.fn(),
+    fileInputRef: { current: null },
+    onFileChange: vi.fn(),
+  }),
+}));
+vi.mock('../../../hooks/useElectron', () => ({
+  copySystemInfo: vi.fn(),
+  desktopDiagnosticsAvailable: () => false,
+  getElectronBridge: () => null,
+  isElectron: () => false,
+  openDeveloperTools: vi.fn(),
+  openServerLog: vi.fn(),
+}));
+vi.mock('../../../hooks/useRunDiagnostic', () => ({
+  useRunDiagnostic: () => vi.fn(),
+}));
+vi.mock('../../../store/settingsUiStore', () => ({
+  useSettingsUiStore: (select: (state: { open: () => void }) => unknown) =>
+    select({ open: vi.fn() }),
+}));
+vi.mock('../../../store/shortcutsUiStore', () => ({
+  useShortcutsUiStore: (select: (state: { open: () => void }) => unknown) =>
+    select({ open: vi.fn() }),
+}));
+vi.mock('../../../store/workspaceStore', () => ({
+  useWorkspaceStore: (
+    select: (state: {
+      capabilities: { canChangeWorkspace: boolean };
+      worldCanvasId: null;
+      worldEnabled: boolean;
+    }) => unknown,
+  ) =>
+    select({
+      capabilities: { canChangeWorkspace: true },
+      worldCanvasId: null,
+      worldEnabled: false,
+    }),
+}));
+vi.mock('../../Common/DropdownMenu', () => ({
+  DropdownMenu: ({ trigger }: { trigger: ReactNode }) => trigger,
+  DropdownMenuItem: () => null,
+  DropdownMenuSubmenu: () => null,
+}));
+
+let root: Root | undefined;
+let container: HTMLDivElement | undefined;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = undefined;
+  container = undefined;
+});
+
+describe('AppMenu', () => {
+  it('gives the hidden Space-import field a stable form name', () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => root?.render(<AppMenu />));
+
+    const fileInput =
+      container.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(fileInput?.name).toBe('space-import-archive');
+  });
+});

--- a/apps/web/src/components/Panels/Header/AppMenu.test.tsx
+++ b/apps/web/src/components/Panels/Header/AppMenu.test.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { act, type ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';

--- a/apps/web/src/components/Panels/Header/AppMenu.tsx
+++ b/apps/web/src/components/Panels/Header/AppMenu.tsx
@@ -107,6 +107,7 @@ export const AppMenu: React.FC<AppMenuProps> = ({
       <input
         ref={fileInputRef}
         type="file"
+        name="space-import-archive"
         accept=".zip,application/zip"
         className="hidden"
         onChange={(e) => void onFileChange(e)}

--- a/apps/web/src/components/Panels/Header/CanvasMenu.tsx
+++ b/apps/web/src/components/Panels/Header/CanvasMenu.tsx
@@ -105,6 +105,8 @@ export const CanvasMenu: React.FC<CanvasMenuProps> = ({ onOpenShortcuts }) => {
       ) : (
         <input
           ref={inputRef}
+          name="space-title"
+          autoComplete="off"
           className="text-fg-default focus:shadow-bottom m-0 max-w-full min-w-8 overflow-hidden bg-transparent px-1 py-1 text-base font-medium text-ellipsis outline-none focus:rounded-md"
           value={draftTitle}
           onChange={(e) => setDraftTitle(e.target.value)}

--- a/apps/web/src/i18n/resources/en/common.json
+++ b/apps/web/src/i18n/resources/en/common.json
@@ -267,6 +267,7 @@
     "searching": "Searching"
   },
   "editor": {
+    "readOnlyContent": "Read-only content",
     "blockType": "Block type",
     "textColor": "Text color",
     "highlightColor": "Highlight color",
@@ -583,8 +584,8 @@
     "agentTeams": "Agent Teams",
     "externalAgents": "External Agents",
     "addAgent": "Add agent",
-    "inputPlaceholder": "Asking anything here...",
-    "operatePlaceholder": "Describe the Space change you want...",
+    "inputPlaceholder": "Asking anything here…",
+    "operatePlaceholder": "Describe the Space change you want…",
     "attachmentFallbackImage": "Image",
     "attachmentFallbackPdf": "PDF",
     "attachmentFallbackFile": "File",

--- a/apps/web/src/i18n/resources/zh-CN/common.json
+++ b/apps/web/src/i18n/resources/zh-CN/common.json
@@ -267,6 +267,7 @@
     "searching": "正在搜索"
   },
   "editor": {
+    "readOnlyContent": "只读内容",
     "blockType": "块类型",
     "textColor": "文字颜色",
     "highlightColor": "高亮颜色",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -333,6 +333,7 @@ body,
    intercept a pan/tap. The link selector out-specifies the exception. */
 [data-canvas-root] .react-flow__attribution,
 [data-canvas-root] .react-flow__attribution a {
+  color: var(--fg-muted);
   -webkit-touch-callout: none;
   -webkit-user-select: none;
   user-select: none;

--- a/apps/web/vite.config.test.ts
+++ b/apps/web/vite.config.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest';
+
+import viteConfig from './vite.config';
+
+describe('Vite feature flags', () => {
+  it('declares Vue esm-bundler defaults used by Milkdown', async () => {
+    if (typeof viteConfig !== 'function') {
+      throw new TypeError('Expected Vite config to be a function');
+    }
+
+    const config = await viteConfig({
+      command: 'serve',
+      mode: 'test',
+      isSsrBuild: false,
+      isPreview: false,
+    });
+
+    expect(config.define).toMatchObject({
+      __VUE_OPTIONS_API__: 'true',
+      __VUE_PROD_DEVTOOLS__: 'false',
+      __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: 'false',
+    });
+  });
+});

--- a/apps/web/vite.config.test.ts
+++ b/apps/web/vite.config.test.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 // @vitest-environment node
 
 import { describe, expect, it } from 'vitest';

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -84,6 +84,12 @@ export default defineConfig(({ mode }) => {
     ],
     define: {
       __APP_VERSION__: JSON.stringify(appVersion),
+      // Milkdown/Crepe mounts Vue components internally. Declare Vue's
+      // esm-bundler flags explicitly using its fallback defaults so dev
+      // does not warn and production can tree-shake the guarded branches.
+      __VUE_OPTIONS_API__: JSON.stringify(true),
+      __VUE_PROD_DEVTOOLS__: JSON.stringify(false),
+      __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: JSON.stringify(false),
     },
     resolve: {
       alias: {


### PR DESCRIPTION
## Summary

- add accessible names and menu/toolbar semantics across the visual-review surfaces
- make split controls, floating toolbars, chat/app menus, and Milkdown preview chrome keyboard- and screen-reader-friendly
- keep visual-only controls out of the accessibility tree where appropriate and add focused regression coverage
- preserve Vite's required production chunk behavior while covering its configuration

## Validation

- focused accessibility suites: 7 files, 10 tests passed
- full web suite: 97 files, 695 tests passed
- web production build passed
- i18n parity and changed-file Prettier checks passed

The web package lint has no errors; its existing `--max-warnings 0` baseline still reports 57 warnings outside this change's scope.
