### PR TITLE
Fix open question avatar spinning

### DIFF
--- a/apps/web/src/components/Nodes/question/QuestionTakeoverMark.test.tsx
+++ b/apps/web/src/components/Nodes/question/QuestionTakeoverMark.test.tsx
@@ -77,6 +77,33 @@ describe('QuestionTakeoverMark', () => {
     });
   });
 
+  it('animates the avatar only while the question is running', () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    const renderMark = (status: QuestionAgentBadgeStatus) => {
+      act(() => {
+        root?.render(
+          <QuestionTakeoverMark
+            state={{ stage: 'collapsed', size: 30 }}
+            status={status}
+            agent={{ kind: 'internal', alias: 'Huabu', mode: 'ask' }}
+            unread={false}
+            conflictCount={0}
+            interactive={false}
+          />,
+        );
+      });
+    };
+
+    renderMark('open');
+    expect(container.querySelector('.agent-icon-working-body')).toBeNull();
+
+    renderMark('running');
+    expect(container.querySelector('.agent-icon-working-body')).not.toBeNull();
+  });
+
   it('renders an interactive mark as an accessible button', () => {
     const onOpen = vi.fn();
     container = document.createElement('div');

--- a/apps/web/src/components/Nodes/question/QuestionTakeoverMark.tsx
+++ b/apps/web/src/components/Nodes/question/QuestionTakeoverMark.tsx
@@ -198,7 +198,7 @@ export function QuestionTakeoverMark({
             agent={agent}
             size={innerSize}
             detail={size >= MARK_FACE_MIN ? 'full' : 'dot'}
-            motion={chip.isRunning || chip.isOpen ? 'working' : 'none'}
+            motion={chip.isRunning ? 'working' : 'none'}
             className="shrink-0"
           />
         </span>


### PR DESCRIPTION
## Summary

- keep question-node avatars static when their conversation is merely open
- reserve working motion for nodes whose execution status is `running`
- add regression coverage for both open and running states

## Validation

- `pnpm --filter @huabu/web test -- src/components/Nodes/question/QuestionTakeoverMark.test.tsx`
- `pnpm --filter @huabu/web typecheck`
- targeted ESLint and Prettier checks