### PR TITLE
fix(canvas): ellipsize overflowing frame labels

### DIFF
--- a/apps/web/src/components/Nodes/frame/FrameNode.tsx
+++ b/apps/web/src/components/Nodes/frame/FrameNode.tsx
@@ -510,7 +510,9 @@ export const FrameNode = memo(
           tooltipOffset={0}
           size={1}
           className={clsx(
-            'nodrag col-start-1 row-start-1 w-full min-w-0! bg-transparent px-1.5 text-xs font-medium outline-none',
+            // `text-ellipsis` only paints on an unfocused input, so the
+            // idle label shows "…" while editing still scrolls normally.
+            'nodrag col-start-1 row-start-1 w-full min-w-0! bg-transparent px-1.5 text-xs font-medium text-ellipsis outline-none',
             isEditingLabel
               ? 'text-fg-default cursor-text'
               : 'text-fg-muted hover:text-fg-default cursor-pointer',

--- a/docs/architecture/canvas-zoom-rendering.md
+++ b/docs/architecture/canvas-zoom-rendering.md
@@ -102,7 +102,7 @@ When frame labels collide, the higher-priority label wins:
 
 The first three interaction states force the affected label to remain visible and use matching overlay layers in descending order. With no interaction, the outer frame wins because zoomed-out views prioritize structural context over nested detail; the inner label returns after sufficient screen-space separation.
 
-Frame label width is capped to the transformed frame width with a 48 px usability floor. Overflowing names truncate visually while the input title retains access to the complete name.
+Frame label width is capped to the transformed frame width with a 48 px usability floor. An overflowing name truncates with an ellipsis so the clipped remainder is visible as such; the ellipsis disappears while the label is being edited, where the input scrolls instead.
 
 `FrameNode` owns the hierarchy and collision policy because it is frame-specific. `NodeWrapper` remains generic: it converts node coordinates to screen coordinates, applies owner-provided semantic visibility and width, handles interaction reveal, and performs opacity/FLIP transitions.
 


### PR DESCRIPTION
Refs #101 (leaving the issue open for now).

## Problem

The frame label is an `<input>` capped to the frame's on-screen width (`overlayMaxWidth = nodeWidth * zoom`) with no `text-overflow`, so a name wider than that cap is hard-clipped mid-character. Nothing indicates the name continues. Zooming out makes it worse: the cap shrinks with the zoom while the label stays at a fixed 12px.

## Change

Add `text-ellipsis` to the frame label input. Chromium only paints `text-overflow` on an unfocused input, so the idle label truncates with `…` while editing keeps the normal scrolling behavior.

Also corrects `docs/architecture/canvas-zoom-rendering.md` §4, which claimed "the input title retains access to the complete name". It never did — the `title` is the static `t('node.editFrameName')` hint.

## Verification

Checked against a running dev build with a frame label forced past its cap:

| State | `clientWidth` | `scrollWidth` | `text-overflow` | Rendering |
| --- | --- | --- | --- | --- |
| Idle (unfocused, `readOnly`) | 179 | 288 | `ellipsis` | `Step 4: Lighting Reference …` |
| Editing (focused) | 179 | 288 | `ellipsis` (not painted) | full text, scrolls + select-all works |

`pnpm typecheck`, `pnpm format`, and `pnpm lint:fix` are all clean.
