### PR TITLE
Fix stale Canvas version conflicts after Agent writes

### DIFF
--- a/apps/web/src/store/canvasStore.portalPinsHistory.test.ts
+++ b/apps/web/src/store/canvasStore.portalPinsHistory.test.ts
@@ -89,6 +89,7 @@ beforeEach(() => {
     pendingSave: false,
     isLoading: true,
     versionConflict: false,
+    versionConflictServerVersion: null,
     worldReferences: {},
     worldReferenceError: null,
     pinnedSourceNodeIds: {},

--- a/apps/web/src/store/canvasStore.structureSaveReconciliation.test.ts
+++ b/apps/web/src/store/canvasStore.structureSaveReconciliation.test.ts
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { putCanvas } = vi.hoisted(() => ({
+  putCanvas: vi.fn(),
+}));
+
+vi.mock('../api', async (importOriginal) => ({
+  ...(await importOriginal<typeof CanvasApi>()),
+  putCanvas,
+}));
+
+import useCanvasStore from './canvasStore';
+import { CanvasConflictError } from '../api/canvas';
+
+import type * as CanvasApi from '../api';
+
+function pendingEffects() {
+  return {
+    mutatedNodes: [],
+    deletedNodeIds: [],
+    contentEditedNodeIds: [],
+    deferredFitFrameIds: [],
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  putCanvas.mockReset();
+  useCanvasStore.getState()._setStateNoAutosave({
+    canvasId: 'canvas-race',
+    nodes: [],
+    edges: [],
+    canvasTitle: 'Race',
+    version: 10,
+    isSaving: false,
+    pendingSave: false,
+    isLoading: true,
+    versionConflict: false,
+    versionConflictServerVersion: null,
+  });
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe('canvasStore structure-save reconciliation', () => {
+  it('does not let a delayed success lower an SSE-advanced version', async () => {
+    let acknowledge:
+      | ((value: { canvasId: string; version: number }) => void)
+      | undefined;
+    putCanvas.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          acknowledge = resolve;
+        }),
+    );
+
+    const save = useCanvasStore.getState().saveCanvas();
+    useCanvasStore.getState().applyDeltasFromAgent([], 12, pendingEffects());
+    acknowledge?.({ canvasId: 'canvas-race', version: 11 });
+    await save;
+
+    expect(useCanvasStore.getState().version).toBe(12);
+    expect(useCanvasStore.getState().versionConflict).toBe(false);
+  });
+
+  it('retries a delayed 409 after SSE already reached its server version', async () => {
+    let rejectSave: ((reason: unknown) => void) | undefined;
+    putCanvas
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectSave = reject;
+          }),
+      )
+      .mockResolvedValueOnce({ canvasId: 'canvas-race', version: 12 });
+
+    const save = useCanvasStore.getState().saveCanvas();
+    useCanvasStore.getState().applyDeltasFromAgent([], 11, pendingEffects());
+    rejectSave?.(
+      new CanvasConflictError({
+        code: 'CANVAS_VERSION_CONFLICT',
+        message: 'Canvas version mismatch',
+        serverVersion: 11,
+      }),
+    );
+    await save;
+    await vi.waitFor(() => expect(putCanvas).toHaveBeenCalledTimes(2));
+
+    expect(putCanvas.mock.calls.map((call) => call[1].version)).toEqual([
+      10, 11,
+    ]);
+    expect(useCanvasStore.getState().version).toBe(12);
+    expect(useCanvasStore.getState().versionConflict).toBe(false);
+  });
+
+  it('clears an earlier 409 and retries when SSE catches up later', async () => {
+    putCanvas
+      .mockRejectedValueOnce(
+        new CanvasConflictError({
+          code: 'CANVAS_VERSION_CONFLICT',
+          message: 'Canvas version mismatch',
+          serverVersion: 11,
+        }),
+      )
+      .mockResolvedValueOnce({ canvasId: 'canvas-race', version: 12 });
+
+    await useCanvasStore.getState().saveCanvas();
+    expect(useCanvasStore.getState().versionConflict).toBe(true);
+    expect(useCanvasStore.getState().versionConflictServerVersion).toBe(11);
+
+    useCanvasStore.getState().applyDeltasFromAgent([], 11, pendingEffects());
+    expect(useCanvasStore.getState().versionConflict).toBe(false);
+
+    await vi.runAllTimersAsync();
+    await vi.waitFor(() => expect(putCanvas).toHaveBeenCalledTimes(2));
+
+    expect(putCanvas.mock.calls[1]?.[1].version).toBe(11);
+    expect(useCanvasStore.getState().version).toBe(12);
+  });
+});

--- a/apps/web/src/store/canvasStore.ts
+++ b/apps/web/src/store/canvasStore.ts
@@ -97,6 +97,10 @@ import { NODE_CONTENT_KEYS } from './canvasStore/save/nodeContentFields';
 import { createNodeContentQueue } from './canvasStore/save/nodeContentQueue';
 import { createPreprocessQueue } from './canvasStore/save/preprocessQueue';
 import { shouldScheduleStructureSave } from './canvasStore/save/structureDirtyDetector';
+import {
+  isCoveredCanvasVersionConflict,
+  reconcileCanvasVersion,
+} from './canvasStore/save/structureSaveReconciliation';
 import { createStructureScheduler } from './canvasStore/save/structureScheduler';
 import { createUnloadFlush } from './canvasStore/save/unloadFlush';
 import { createResizePreviewController } from './canvasStore/slices/resizePreview';
@@ -450,10 +454,15 @@ type RFState = {
    * True when the server has rejected a save with `CANVAS_VERSION_CONFLICT`
    * (another tab / device / agent advanced the canvas behind our back).
    * While set, `saveCanvas` short-circuits so we don't pile up failing
-   * autosaves on top of stale state. Cleared by `loadCanvas` once the
-   * client is re-synced to the latest server snapshot.
+   * autosaves on top of stale state. Cleared by `loadCanvas` or when Canvas
+   * Sync reaches the server version reported by the conflict.
    */
   versionConflict: boolean;
+  /**
+   * Server version reported by the rejected structure PUT. Canvas Sync clears
+   * the conflict and retries once an incoming update reaches this version.
+   */
+  versionConflictServerVersion: number | null;
 
   /**
    * Apply a partial state update without triggering autosave or the
@@ -1269,6 +1278,7 @@ const useCanvasStore = create<RFState>()(
     isSaving: false,
     pendingSave: false,
     versionConflict: false,
+    versionConflictServerVersion: null,
 
     refreshWorldReferences: async () => {
       const generation = ++worldReferenceRefreshGeneration;
@@ -1520,6 +1530,28 @@ const useCanvasStore = create<RFState>()(
      *      the legacy full-state snapshot boundary.
      */
     applyDeltasFromAgent: (deltas, toVersion, pendingEffects) => {
+      const reconcileIncomingVersion = (): void => {
+        const current = get();
+        const reconciled = reconcileCanvasVersion(
+          current.version,
+          toVersion,
+          current.versionConflictServerVersion,
+        );
+        get()._setStateNoAutosave({
+          version: reconciled.version,
+          ...(reconciled.conflictResolved
+            ? {
+                versionConflict: false,
+                versionConflictServerVersion: null,
+              }
+            : {}),
+        });
+        if (reconciled.conflictResolved) {
+          dismissVersionConflictToast();
+          structureScheduler.schedule();
+        }
+      };
+
       // Never let an incoming agent write clobber a
       // node the user is mid-editing. Skip REPLACE/DELETE deltas that
       // target a node with un-persisted local content edits (INSERT is a
@@ -1560,9 +1592,7 @@ const useCanvasStore = create<RFState>()(
         // Nothing to apply locally (empty batch, or every row protected).
         // Still reconcile the version so the next local edit's autosave
         // doesn't 409 against our stale view of server state.
-        if (get().version !== toVersion) {
-          get()._setStateNoAutosave({ version: toVersion });
-        }
+        reconcileIncomingVersion();
         return skippedNodeIds;
       }
 
@@ -1612,9 +1642,9 @@ const useCanvasStore = create<RFState>()(
       get()._setStateNoAutosave({
         nodes: orderedNodes as Node[],
         edges: applied.edges as Edge[],
-        version: toVersion,
         ...(isPortalPinMutation ? { canUndo: false, canRedo: false } : {}),
       });
+      reconcileIncomingVersion();
 
       // Re-seed the content-CAS baseline for the nodes this agent write
       // actually applied. Skipped mid-edit nodes had their baseline adopted
@@ -1843,7 +1873,12 @@ const useCanvasStore = create<RFState>()(
     },
 
     loadCanvas: async (canvasId, options) => {
-      set({ isLoading: true, canvasNotFound: false, versionConflict: false });
+      set({
+        isLoading: true,
+        canvasNotFound: false,
+        versionConflict: false,
+        versionConflictServerVersion: null,
+      });
       // Clear any stale "modified elsewhere" toast before we fetch a
       // fresh baseline — the warning is bound to the old version we're
       // about to replace.
@@ -2025,6 +2060,7 @@ const useCanvasStore = create<RFState>()(
         isLoading: true,
         canvasNotFound: false,
         versionConflict: false,
+        versionConflictServerVersion: null,
       });
       // Same rationale as `loadCanvas`: the persistent conflict toast
       // is bound to the outgoing canvas; clear it so it doesn't bleed
@@ -2056,10 +2092,9 @@ const useCanvasStore = create<RFState>()(
     },
 
     saveCanvas: async (options) => {
-      // Once the server has rejected a save with a version mismatch, our
-      // local `version` is permanently stale until the user reloads. Skip
-      // further attempts so we don't generate a 409 on every autosave tick
-      // (and don't clobber the surfaced toast with more failures).
+      // Pause structure saves after an unresolved version mismatch so we do
+      // not pile up 409s. Canvas Sync automatically clears this gate and
+      // retries once it reaches the server version reported by the conflict.
       if (get().versionConflict) return;
 
       const { isSaving } = get();
@@ -2105,11 +2140,36 @@ const useCanvasStore = create<RFState>()(
           },
           { keepalive: options?.keepalive },
         );
-        set({ version: response.version });
+        const reconciled = reconcileCanvasVersion(
+          get().version,
+          response.version,
+          get().versionConflictServerVersion,
+        );
+        set({
+          version: reconciled.version,
+          ...(reconciled.conflictResolved
+            ? {
+                versionConflict: false,
+                versionConflictServerVersion: null,
+              }
+            : {}),
+        });
+        if (reconciled.conflictResolved) {
+          dismissVersionConflictToast();
+        }
         saveSucceeded = true;
       } catch (error) {
         if (error instanceof CanvasConflictError) {
           if (error.code === 'CANVAS_VERSION_CONFLICT') {
+            if (
+              isCoveredCanvasVersionConflict(get().version, error.serverVersion)
+            ) {
+              // Canvas Sync already delivered the winning write. Retry the
+              // latest local structure against that fresh baseline instead
+              // of turning this delayed response into a global conflict.
+              set({ pendingSave: true });
+              return;
+            }
             // Server is ahead of us (another tab / device / agent wrote
             // first). Stop the autosave loop and surface a persistent
             // toast (with a Reload action) so the user knows their edits
@@ -2118,7 +2178,10 @@ const useCanvasStore = create<RFState>()(
             // first; `loadCanvas` clears the flag (and the toast) once
             // the client re-syncs.
             if (!get().versionConflict) {
-              set({ versionConflict: true });
+              set({
+                versionConflict: true,
+                versionConflictServerVersion: error.serverVersion ?? null,
+              });
               showVersionConflictToast();
             }
             return;

--- a/apps/web/src/store/canvasStore/save/__tests__/structureSaveReconciliation.test.ts
+++ b/apps/web/src/store/canvasStore/save/__tests__/structureSaveReconciliation.test.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  isCoveredCanvasVersionConflict,
+  reconcileCanvasVersion,
+} from '../structureSaveReconciliation';
+
+describe('structure save version reconciliation', () => {
+  it('does not let a delayed save acknowledgement roll back an SSE version', () => {
+    expect(reconcileCanvasVersion(12, 11, null)).toEqual({
+      version: 12,
+      conflictResolved: false,
+    });
+  });
+
+  it('treats a delayed 409 as covered after SSE reaches its server version', () => {
+    expect(isCoveredCanvasVersionConflict(12, 12)).toBe(true);
+    expect(isCoveredCanvasVersionConflict(13, 12)).toBe(true);
+    expect(isCoveredCanvasVersionConflict(11, 12)).toBe(false);
+  });
+
+  it('resolves a latched conflict when a later SSE update catches up', () => {
+    expect(reconcileCanvasVersion(11, 12, 12)).toEqual({
+      version: 12,
+      conflictResolved: true,
+    });
+  });
+});

--- a/apps/web/src/store/canvasStore/save/structureSaveReconciliation.ts
+++ b/apps/web/src/store/canvasStore/save/structureSaveReconciliation.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export interface CanvasVersionReconciliation {
+  version: number;
+  conflictResolved: boolean;
+}
+
+/**
+ * Reconcile an acknowledged server version without allowing an older HTTP
+ * response to roll back a version already advanced by Canvas Sync.
+ */
+export function reconcileCanvasVersion(
+  currentVersion: number,
+  acknowledgedVersion: number,
+  conflictServerVersion: number | null,
+): CanvasVersionReconciliation {
+  const version = Math.max(currentVersion, acknowledgedVersion);
+  return {
+    version,
+    conflictResolved:
+      conflictServerVersion !== null && version >= conflictServerVersion,
+  };
+}
+
+/**
+ * A version-conflict response is stale when another channel has already
+ * advanced the client to the server version reported by that response.
+ */
+export function isCoveredCanvasVersionConflict(
+  currentVersion: number,
+  serverVersion: number | undefined,
+): boolean {
+  return serverVersion !== undefined && currentVersion >= serverVersion;
+}

--- a/docs/architecture/canvas-realtime-sync.md
+++ b/docs/architecture/canvas-realtime-sync.md
@@ -108,6 +108,7 @@ otherwise                → apply
   `loadCanvas` — but **only when there are no dirty nodes**. With local dirty
   state a blind `loadCanvas` would lose the edit, so the tab defers to autosave's
   409 path (existing sticky "modified elsewhere" toast + Reload) instead.
+- Structure-save acknowledgements reconcile monotonically with Canvas Sync: a delayed HTTP success cannot lower the local version, and a delayed 409 whose reported server version has already arrived over SSE is retried against that fresh baseline instead of opening the global conflict state. If the 409 arrives first, the client records its server version; a later SSE update that reaches that version clears the warning and schedules the latest structure for retry.
 - **Scope:** content only. Same-node _structure_ conflicts (geometry / parent)
   stay coarse — there is no per-node structure-dirty tracking yet.
 


### PR DESCRIPTION
## Summary

- keep Canvas structure-save acknowledgements monotonic with SSE-delivered versions
- retry delayed 409 responses when Canvas Sync has already reached the reported server version
- clear an earlier conflict and reschedule the latest structure save when a later SSE update catches up
- document the recovery contract and add deterministic response-order regression tests

This is the focused stage-one emergency fix for #98. It removes the common false global Reload state while preserving the existing fallback for unresolved version gaps; broader write-path and incremental-gap work remains follow-up scope.

## Validation

- `pnpm typecheck`
- `pnpm format`
- `pnpm lint:fix`
- targeted web tests: 17 passed