### PR TITLE
Compact toolbar color picker palette

### DIFF
--- a/apps/web/src/components/Common/ColorPicker.tsx
+++ b/apps/web/src/components/Common/ColorPicker.tsx
@@ -39,7 +39,7 @@ export const ColorPicker = ({
   onSelect,
 }: ColorPickerProps) => {
   return (
-    <div className="flex gap-2">
+    <div className="flex gap-0">
       {colors.map((c) => {
         const isTransparent = c.value === 'transparent' || !c.value;
         return (
@@ -49,29 +49,32 @@ export const ColorPicker = ({
             iconOnly
             size="sm"
             onClick={() => onSelect(c.token)}
-            className={clsx(
-              'h-4 w-4 rounded-full border-2 border-solid p-0 transition-transform hover:scale-110',
-              activeToken === c.token
-                ? 'border-info scale-110'
-                : 'border-edge-default',
-            )}
-            style={
-              isTransparent
-                ? {
-                    // Checkerboard pattern: makes "no fill" instantly
-                    // recognisable instead of looking like a white swatch.
-                    backgroundColor: 'var(--bg-surface)',
-                    backgroundImage:
-                      'linear-gradient(45deg, var(--fg-subtle) 25%, transparent 25%, transparent 75%, var(--fg-subtle) 75%), linear-gradient(45deg, var(--fg-subtle) 25%, transparent 25%, transparent 75%, var(--fg-subtle) 75%)',
-                    backgroundSize: '6px 6px',
-                    backgroundPosition: '0 0, 3px 3px',
-                  }
-                : { backgroundColor: c.value }
-            }
+            className="group h-6 w-6 rounded-full p-0 enabled:hover:bg-transparent"
             title={c.name}
             aria-label={c.name}
           >
-            <span className="sr-only">{c.name}</span>
+            <span
+              aria-hidden
+              className={clsx(
+                'h-3.5 w-3.5 shrink-0 rounded-full border-2 border-solid transition-transform group-hover:scale-110',
+                activeToken === c.token
+                  ? 'border-info scale-110'
+                  : 'border-edge-default',
+              )}
+              style={
+                isTransparent
+                  ? {
+                      // Checkerboard pattern: makes "no fill" instantly
+                      // recognisable instead of looking like a white swatch.
+                      backgroundColor: 'var(--bg-surface)',
+                      backgroundImage:
+                        'linear-gradient(45deg, var(--fg-subtle) 25%, transparent 25%, transparent 75%, var(--fg-subtle) 75%), linear-gradient(45deg, var(--fg-subtle) 25%, transparent 25%, transparent 75%, var(--fg-subtle) 75%)',
+                      backgroundSize: '6px 6px',
+                      backgroundPosition: '0 0, 3px 3px',
+                    }
+                  : { backgroundColor: c.value }
+              }
+            />
           </Button>
         );
       })}

--- a/apps/web/src/components/Common/FloatingToolbar.test.tsx
+++ b/apps/web/src/components/Common/FloatingToolbar.test.tsx
@@ -59,7 +59,20 @@ describe('FloatingToolbar.ColorPicker', () => {
       'button[aria-label="Red"]',
     ) as HTMLButtonElement | null;
     expect(redSwatch).not.toBeNull();
-    expect(redSwatch?.classList.contains('border-solid')).toBe(true);
+    expect(redSwatch?.closest('div.flex.gap-0')).not.toBeNull();
+    expect(redSwatch?.classList.contains('h-6')).toBe(true);
+    expect(redSwatch?.classList.contains('min-h-6')).toBe(true);
+    expect(redSwatch?.classList.contains('w-6')).toBe(true);
+    expect(redSwatch?.classList.contains('min-w-6')).toBe(true);
+    expect(redSwatch?.classList.contains('enabled:hover:bg-transparent')).toBe(
+      true,
+    );
+    expect(redSwatch?.classList.contains('enabled:hover:bg-hover')).toBe(false);
+
+    const redDot = redSwatch?.querySelector('span[aria-hidden]');
+    expect(redDot?.classList.contains('border-solid')).toBe(true);
+    expect(redDot?.classList.contains('h-3.5')).toBe(true);
+    expect(redDot?.classList.contains('w-3.5')).toBe(true);
 
     act(() => {
       redSwatch?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));

--- a/apps/web/src/components/Common/FloatingToolbar.tsx
+++ b/apps/web/src/components/Common/FloatingToolbar.tsx
@@ -360,7 +360,7 @@ function ToolbarColorPicker({
                 ref={refs.setFloating}
                 role="presentation"
                 {...FLOATING_CHROME_PROPS}
-                className={FLOATING_TOOLBAR_POPOVER_CLASS}
+                className={cn(FLOATING_TOOLBAR_POPOVER_CLASS, 'px-1.5 py-1')}
                 style={{
                   ...floatingStyles,
                   visibility: isPositioned ? 'visible' : 'hidden',


### PR DESCRIPTION
## Summary

- render 14px color dots inside non-overlapping 24px button targets
- remove extra palette gap and the oversized ghost-button hover halo
- tighten the toolbar color popover padding and cover the layout contract with a regression test

## Validation

- `pnpm --filter @huabu/web exec vitest run src/components/Common/FloatingToolbar.test.tsx`
- `pnpm exec eslint apps/web/src/components/Common/ColorPicker.tsx apps/web/src/components/Common/FloatingToolbar.tsx apps/web/src/components/Common/FloatingToolbar.test.tsx`
- `pnpm exec prettier --check apps/web/src/components/Common/ColorPicker.tsx apps/web/src/components/Common/FloatingToolbar.tsx apps/web/src/components/Common/FloatingToolbar.test.tsx`
- `git diff --check`