### PR TITLE
Fix PDF preview failures after tab switching

### DIFF
--- a/apps/web/src/components/Nodes/pdf/PDFPreview.tsx
+++ b/apps/web/src/components/Nodes/pdf/PDFPreview.tsx
@@ -45,7 +45,8 @@ import {
 import { PDFPageWithOverlay } from './PDFPageWithOverlay';
 import { findPdfTextMatches } from './pdfTextIndex';
 import { PDF_DOCUMENT_OPTIONS } from './pdfWorker';
-import { usePdfTextIndex, type PdfIndexDocument } from './usePdfTextIndex';
+import { usePdfDocumentLifecycle } from './usePdfDocumentLifecycle';
+import { usePdfTextIndex } from './usePdfTextIndex';
 import { Button } from '../../Common/Button';
 import { Loading } from '../../Common/Loading';
 
@@ -87,9 +88,12 @@ export const PDFPreview = ({
   const previewSearchNodeId = usePreviewSearchStore((s) => s.nodeId);
   const searchQuery = usePreviewSearchStore((s) => s.query);
   const isPreviewSearchOpen = usePreviewSearchStore((s) => s.isOpen);
-  const [numPages, setNumPages] = useState<number | null>(null);
-  const [pdfDocument, setPdfDocument] = useState<PdfIndexDocument | null>(null);
-  const [docLoaded, setDocLoaded] = useState(false);
+  const {
+    document: pdfDocument,
+    numPages,
+    isLoaded: docLoaded,
+    handleLoadSuccess: onDocumentLoadSuccess,
+  } = usePdfDocumentLifecycle(src);
   const [forcedPageIndex, setForcedPageIndex] = useState<number | null>(null);
   const searchNavigationCancelRef = useRef<(() => void) | null>(null);
   const [visiblePageIndexes, setVisiblePageIndexes] = useState<
@@ -103,9 +107,6 @@ export const PDFPreview = ({
   >(() => new Map());
   // Reset loading state when the PDF source changes.
   useEffect(() => {
-    setDocLoaded(false);
-    setNumPages(null);
-    setPdfDocument(null);
     setForcedPageIndex(null);
     setVisiblePageIndexes(new Set([0]));
     setRetainedPageIndexes(new Set([0]));
@@ -360,12 +361,6 @@ export const PDFPreview = ({
     renderedWidth > 0 && containerWidth > 0
       ? containerWidth / renderedWidth
       : 1;
-
-  const onDocumentLoadSuccess = useCallback((document: PdfIndexDocument) => {
-    setPdfDocument(document);
-    setNumPages(document.numPages);
-    setDocLoaded(true);
-  }, []);
 
   const handlePageAspectRatioResolved = useCallback(
     (pageIndex: number, aspectRatio: number) => {

--- a/apps/web/src/components/Nodes/pdf/usePdfDocumentLifecycle.test.tsx
+++ b/apps/web/src/components/Nodes/pdf/usePdfDocumentLifecycle.test.tsx
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { act, Activity, useEffect } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { usePdfDocumentLifecycle } from './usePdfDocumentLifecycle';
+
+import type { PdfIndexDocument } from './usePdfTextIndex';
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function Harness({
+  onDocumentEffect,
+}: {
+  onDocumentEffect: (document: PdfIndexDocument | null) => void;
+}) {
+  const { document, handleLoadSuccess } = usePdfDocumentLifecycle('test.pdf');
+
+  useEffect(() => {
+    onDocumentEffect(document);
+  }, [document, onDocumentEffect]);
+
+  return (
+    <button
+      type="button"
+      onClick={() => handleLoadSuccess({ numPages: 1, getPage: vi.fn() })}
+    >
+      Load
+    </button>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe('usePdfDocumentLifecycle', () => {
+  it('discards a destroyed proxy before Activity effects restart', async () => {
+    const observedDocuments: Array<PdfIndexDocument | null> = [];
+    const onDocumentEffect = (document: PdfIndexDocument | null) => {
+      observedDocuments.push(document);
+    };
+    const render = (mode: 'visible' | 'hidden') => {
+      root.render(
+        <Activity mode={mode}>
+          <Harness onDocumentEffect={onDocumentEffect} />
+        </Activity>,
+      );
+    };
+
+    await act(async () => render('visible'));
+    act(() => container.querySelector('button')?.click());
+    expect(observedDocuments.at(-1)).not.toBeNull();
+
+    await act(async () => render('hidden'));
+    observedDocuments.length = 0;
+    await act(async () => render('visible'));
+
+    expect(observedDocuments).toEqual([null]);
+  });
+});

--- a/apps/web/src/components/Nodes/pdf/usePdfDocumentLifecycle.ts
+++ b/apps/web/src/components/Nodes/pdf/usePdfDocumentLifecycle.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { useCallback, useEffect, useState } from 'react';
+
+import type { PdfIndexDocument } from './usePdfTextIndex';
+
+export function usePdfDocumentLifecycle(source: string) {
+  const [numPages, setNumPages] = useState<number | null>(null);
+  const [document, setDocument] = useState<PdfIndexDocument | null>(null);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    setIsLoaded(false);
+    setNumPages(null);
+    setDocument(null);
+  }, [source]);
+
+  useEffect(() => {
+    return () => {
+      // React Activity preserves state but react-pdf destroys its document
+      // proxy while the tab is hidden. Discard that stale proxy before the
+      // effects restart so Page and the text index wait for a fresh load.
+      setIsLoaded(false);
+      setNumPages(null);
+      setDocument(null);
+    };
+  }, []);
+
+  const handleLoadSuccess = useCallback((nextDocument: PdfIndexDocument) => {
+    setDocument(nextDocument);
+    setNumPages(nextDocument.numPages);
+    setIsLoaded(true);
+  }, []);
+
+  return { document, numPages, isLoaded, handleLoadSuccess };
+}

--- a/docs/architecture/preview-workspace.md
+++ b/docs/architecture/preview-workspace.md
@@ -74,6 +74,8 @@ Canvas search results and connected-node navigation open transiently. Explicit n
 
 Each group mounts its active tab plus at most one warm inactive tab selected by the greatest `lastActiveSeq`. The warm slot is a bounded runtime optimization rather than persisted topology: React 19 `Activity` keeps that tab's DOM and component state with `mode="hidden"`, cleans up its Effects while hidden, and restarts those Effects when the tab becomes visible again. Activity cleanup and closing a tab do not mark the page as unloading or terminate a thread-owned stream; only the browser page lifecycle suppresses unload-time transport errors.
 
+PDF tabs retain view state in the warm slot, but discard the loaded pdf.js document proxy during Activity cleanup because `react-pdf` destroys that proxy's worker transport while hidden. Page rendering and text indexing remain suspended until the visible tab loads a fresh proxy.
+
 Chat, Question, Note, Text, PDF, and Office tabs are eligible for the warm slot. Eligibility follows the resolved renderer, so a valid World `nodeRef` that presents a source Question is treated as a Question rather than as a generic reference. Web, Audio, Video, and other node types are not retained because hidden native media or iframe work can outlive React Effect cleanup. Closing or replacing a warm tab, deleting its node, or advancing the slot to a more recently active eligible tab unmounts the old tree. The shared runtime scroll cache remains the cold-restore fallback after a real unmount.
 
 `PreviewRenderer` resolves node targets against the current Canvas nodes and World references. Ordinary nodes render through `ExpandedNodePanel`; Question nodes and unbound Chat targets render through `ChatPanel`.


### PR DESCRIPTION
## Summary

- discard the stale pdf.js document proxy when React Activity hides a warm PDF tab
- wait for `react-pdf` to load a fresh proxy before page rendering or text indexing resumes
- add a React Activity lifecycle regression test and document the resource lifecycle

## Validation

- `pnpm typecheck`
- `pnpm format`
- `pnpm lint:fix`
- `pnpm --filter @huabu/web exec vitest run src/components/Nodes/pdf/usePdfDocumentLifecycle.test.tsx src/components/Nodes/pdf/pdfTextIndex.test.ts src/components/Nodes/pdf/pdfPageRendering.test.ts`
- `pnpm --filter @huabu/web typecheck`
- targeted Prettier check