### PR TITLE
Enforce transient preview lifecycle and sync thread settings

### DIFF
--- a/apps/web/src/components/Nodes/question/QuestionNode.tsx
+++ b/apps/web/src/components/Nodes/question/QuestionNode.tsx
@@ -174,60 +174,68 @@ export const QuestionNode = memo(
     // ------------------------------------------------------------------
     // Open an already-run question's conversation (live or replay).
     // ------------------------------------------------------------------
-    const openInChat = useCallback(() => {
-      if (!data.threadId) return;
-      enterQuestionConversation(
-        {
-          presentationAnchor: { canvasId, nodeId: id },
-          conversationOwner: {
-            canvasId,
-            nodeId: id,
-            threadId: data.threadId,
+    const openInChat = useCallback(
+      (transient = false) => {
+        if (!data.threadId) return;
+        enterQuestionConversation(
+          {
+            presentationAnchor: { canvasId, nodeId: id },
+            conversationOwner: {
+              canvasId,
+              nodeId: id,
+              threadId: data.threadId,
+            },
           },
-        },
+          data.agentBinding,
+          canvasId,
+          needsApproval
+            ? 'bottom'
+            : hasRun && !data.viewed
+              ? 'last-user'
+              : 'bottom',
+          { transient },
+        );
+        // Mark as viewed only once the run has finished.
+        if (hasRun && !data.viewed) {
+          patchNodeSilent(id, { viewed: true });
+        }
+      },
+      [
+        id,
+        data.threadId,
         data.agentBinding,
+        data.viewed,
+        needsApproval,
+        hasRun,
         canvasId,
-        needsApproval
-          ? 'bottom'
-          : hasRun && !data.viewed
-            ? 'last-user'
-            : 'bottom',
-      );
-      // Mark as viewed only once the run has finished.
-      if (hasRun && !data.viewed) {
-        patchNodeSilent(id, { viewed: true });
-      }
-    }, [
-      id,
-      data.threadId,
-      data.agentBinding,
-      data.viewed,
-      needsApproval,
-      hasRun,
-      canvasId,
-      patchNodeSilent,
-    ]);
+        patchNodeSilent,
+      ],
+    );
 
     // ------------------------------------------------------------------
     // Open this node for composition: switch the chat panel to the
     // node's (empty) thread, expand it, and focus the input. Mints a
     // thread id on first use so the node + its conversation are bound.
     // ------------------------------------------------------------------
-    const openInCompose = useCallback(() => {
-      let threadId = data.threadId;
-      if (!threadId) {
-        threadId = createId('thread');
-        patchNodeSilent(id, { threadId });
-      }
-      enterQuestionCompose(
-        {
-          presentationAnchor: { canvasId, nodeId: id },
-          conversationOwner: { canvasId, nodeId: id, threadId },
-        },
-        canvasId,
-        data.agentBinding,
-      );
-    }, [id, data.threadId, data.agentBinding, canvasId, patchNodeSilent]);
+    const openInCompose = useCallback(
+      (transient = false) => {
+        let threadId = data.threadId;
+        if (!threadId) {
+          threadId = createId('thread');
+          patchNodeSilent(id, { threadId });
+        }
+        enterQuestionCompose(
+          {
+            presentationAnchor: { canvasId, nodeId: id },
+            conversationOwner: { canvasId, nodeId: id, threadId },
+          },
+          canvasId,
+          data.agentBinding,
+          { transient },
+        );
+      },
+      [id, data.threadId, data.agentBinding, canvasId, patchNodeSilent],
+    );
 
     // ------------------------------------------------------------------
     // Double-click:
@@ -240,9 +248,9 @@ export const QuestionNode = memo(
         e.stopPropagation();
         if (isForkPending) return;
         if (canOpenInChat) {
-          openInChat();
+          openInChat(true);
         } else {
-          openInCompose();
+          openInCompose(true);
         }
       },
       [isForkPending, canOpenInChat, openInChat, openInCompose],
@@ -262,14 +270,14 @@ export const QuestionNode = memo(
                 ? t('node.watchLiveConversation')
                 : t('node.viewConversation')
             }
-            onClick={openInChat}
+            onClick={() => openInChat(true)}
           >
             <MessageSquare size={14} />
           </FloatingToolbar.ActionButton>
         ) : (
           <FloatingToolbar.ActionButton
             title={t('node.ask')}
-            onClick={openInCompose}
+            onClick={() => openInCompose(true)}
           >
             <MessageSquare size={14} />
           </FloatingToolbar.ActionButton>

--- a/apps/web/src/components/Nodes/question/questionCompose.test.ts
+++ b/apps/web/src/components/Nodes/question/questionCompose.test.ts
@@ -61,6 +61,17 @@ describe('Question conversation presentation', () => {
     });
   });
 
+  it('opens an authored Question transiently when requested by inspection', () => {
+    enterQuestionConversation(view, undefined, 'canvas-1', 'bottom', {
+      transient: true,
+    });
+
+    const activeTab = Object.values(
+      usePreviewWorkspaceStore.getState().workspace.tabs,
+    )[0];
+    expect(activeTab.transient).toBe(true);
+  });
+
   it('opens Question compose as a workspace tab and focuses its thread', () => {
     enterQuestionCompose(view, 'canvas-1');
 
@@ -73,6 +84,15 @@ describe('Question conversation presentation', () => {
     expect(usePanelStore.getState().focusChatInputRequest?.threadId).toBe(
       'thread-1',
     );
+  });
+
+  it('opens Question compose transiently when requested by inspection', () => {
+    enterQuestionCompose(view, 'canvas-1', undefined, { transient: true });
+
+    const activeTab = Object.values(
+      usePreviewWorkspaceStore.getState().workspace.tabs,
+    )[0];
+    expect(activeTab.transient).toBe(true);
   });
 
   it('inherits the Canvas binding for a new Question thread', () => {

--- a/apps/web/src/components/Nodes/question/questionCompose.ts
+++ b/apps/web/src/components/Nodes/question/questionCompose.ts
@@ -47,12 +47,13 @@ export function enterQuestionConversation(
   binding: AgentBinding | undefined,
   canvasId: string | null,
   openPosition: 'last-user' | 'bottom',
+  options?: { transient?: boolean },
 ): void {
   useChatStore
     .getState()
     .makeThreadMetadataEphemeral(view.conversationOwner.threadId);
   initializeQuestionBinding(view, binding, canvasId, false);
-  const tabId = openPreviewNode(view.presentationAnchor.nodeId);
+  const tabId = openPreviewNode(view.presentationAnchor.nodeId, options);
   if (tabId) {
     usePreviewWorkspaceStore.getState().requestChatOpen(tabId, openPosition);
   }
@@ -66,9 +67,10 @@ export function enterQuestionCompose(
   view: AgentConversationView,
   canvasId: string | null,
   binding?: AgentBinding,
+  options?: { transient?: boolean },
 ): void {
   initializeQuestionBinding(view, binding, canvasId, true);
-  openPreviewNode(view.presentationAnchor.nodeId);
+  openPreviewNode(view.presentationAnchor.nodeId, options);
   usePanelStore
     .getState()
     .requestFocusChatInput(view.conversationOwner.threadId);

--- a/apps/web/src/components/Panels/PreviewWorkspace/PreviewWorkspace.tsx
+++ b/apps/web/src/components/Panels/PreviewWorkspace/PreviewWorkspace.tsx
@@ -261,8 +261,7 @@ export function PreviewWorkspace({
   const closeWorkspaceTab = (tabId: string) => {
     const currentWorkspace = usePreviewWorkspaceStore.getState().workspace;
     const isFinalTab = Object.keys(currentWorkspace.tabs).length === 1;
-    settleTab(tabId);
-    closeTab(tabId);
+    closeTab(tabId, settleTab);
     if (isFinalTab) onCollapse?.();
   };
   const openPreviewTarget = usePreviewWorkspaceStore(
@@ -276,10 +275,14 @@ export function PreviewWorkspace({
       // target, so it goes through the same open path (§8).
       if (tab) {
         settleTab(tabId);
-        openPreviewTarget(tab.target, {
-          openToSide: true,
-          transient: tab.transient,
-        });
+        openPreviewTarget(
+          tab.target,
+          {
+            openToSide: true,
+            transient: tab.transient,
+          },
+          settleTab,
+        );
       }
     },
     [openPreviewTarget, settleTab],
@@ -337,7 +340,7 @@ export function PreviewWorkspace({
       );
       if (!destination) return;
       settleTab(tabId);
-      moveTab(tabId, destination);
+      moveTab(tabId, destination, settleTab);
       activateTab(tabId);
     },
     [activateTab, clearTabDrag, moveTab, settleTab],

--- a/apps/web/src/hooks/useBuiltinThreadSettings.test.tsx
+++ b/apps/web/src/hooks/useBuiltinThreadSettings.test.tsx
@@ -26,9 +26,12 @@ vi.mock('@/api/llm', () => ({
 }));
 
 const THREAD_ID = 'thread-idle';
+let settingsSeenAfterSelection:
+  | { modelId: string | null; reasoningEffort: string | null }
+  | undefined;
 
 function Harness() {
-  const { settings } = useBuiltinThreadSettings({
+  const { settings, selectReasoningEffort } = useBuiltinThreadSettings({
     threadId: THREAD_ID,
     canvasId: 'canvas-1',
     provider: 'test-provider',
@@ -37,9 +40,23 @@ function Harness() {
     threadHasMessages: false,
   });
   return (
-    <span>
-      {settings.modelId}:{settings.reasoningEffort}
-    </span>
+    <>
+      <span data-testid="settings">
+        {settings.modelId}:{settings.reasoningEffort}
+      </span>
+      <button
+        type="button"
+        onClick={async () => {
+          await selectReasoningEffort('medium');
+          settingsSeenAfterSelection = selectThreadSettings(
+            useChatStore.getState(),
+            THREAD_ID,
+          );
+        }}
+      >
+        Select medium
+      </button>
+    </>
   );
 }
 
@@ -47,6 +64,7 @@ let root: Root | undefined;
 let container: HTMLDivElement | undefined;
 
 beforeEach(() => {
+  settingsSeenAfterSelection = undefined;
   apiMocks.getModels.mockClear();
   apiMocks.getSettings.mockReset();
   apiMocks.getSettings.mockRejectedValue(new Error('Thread not found'));
@@ -77,11 +95,33 @@ describe('useBuiltinThreadSettings', () => {
       await Promise.resolve();
     });
 
-    expect(container.textContent).toBe('model-1:high');
+    expect(
+      container.querySelector('[data-testid="settings"]')?.textContent,
+    ).toBe('model-1:high');
     expect(selectThreadSettings(useChatStore.getState(), THREAD_ID)).toEqual({
       modelId: 'model-1',
       reasoningEffort: 'high',
     });
     expect(apiMocks.getSettings).not.toHaveBeenCalled();
+  });
+
+  it('updates the send-path cache before a pre-first-message selection returns', async () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<Harness />);
+    });
+
+    await act(async () => {
+      container?.querySelector('button')?.click();
+      await Promise.resolve();
+    });
+
+    expect(settingsSeenAfterSelection).toEqual({
+      modelId: 'model-1',
+      reasoningEffort: 'medium',
+    });
   });
 });

--- a/apps/web/src/hooks/useBuiltinThreadSettings.test.tsx
+++ b/apps/web/src/hooks/useBuiltinThreadSettings.test.tsx
@@ -31,14 +31,15 @@ let settingsSeenAfterSelection:
   | undefined;
 
 function Harness() {
-  const { settings, selectReasoningEffort } = useBuiltinThreadSettings({
-    threadId: THREAD_ID,
-    canvasId: 'canvas-1',
-    provider: 'test-provider',
-    defaultModelId: 'default-model',
-    enabled: true,
-    threadHasMessages: false,
-  });
+  const { settings, selectModel, selectReasoningEffort } =
+    useBuiltinThreadSettings({
+      threadId: THREAD_ID,
+      canvasId: 'canvas-1',
+      provider: 'test-provider',
+      defaultModelId: 'default-model',
+      enabled: true,
+      threadHasMessages: false,
+    });
   return (
     <>
       <span data-testid="settings">
@@ -55,6 +56,20 @@ function Harness() {
         }}
       >
         Select medium
+      </button>
+      <button
+        type="button"
+        data-testid="select-model-and-effort"
+        onClick={() => {
+          void selectModel('model-2');
+          void selectReasoningEffort('medium');
+          settingsSeenAfterSelection = selectThreadSettings(
+            useChatStore.getState(),
+            THREAD_ID,
+          );
+        }}
+      >
+        Select model and effort
       </button>
     </>
   );
@@ -121,6 +136,29 @@ describe('useBuiltinThreadSettings', () => {
 
     expect(settingsSeenAfterSelection).toEqual({
       modelId: 'model-1',
+      reasoningEffort: 'medium',
+    });
+  });
+
+  it('preserves consecutive selections made before React re-renders', async () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<Harness />);
+    });
+
+    await act(async () => {
+      container
+        ?.querySelector<HTMLButtonElement>(
+          '[data-testid="select-model-and-effort"]',
+        )
+        ?.click();
+    });
+
+    expect(settingsSeenAfterSelection).toEqual({
+      modelId: 'model-2',
       reasoningEffort: 'medium',
     });
   });

--- a/apps/web/src/hooks/useBuiltinThreadSettings.ts
+++ b/apps/web/src/hooks/useBuiltinThreadSettings.ts
@@ -67,6 +67,14 @@ export function useBuiltinThreadSettings({
         ? selectThreadSettings(useChatStore.getState(), threadId)
         : EMPTY_SETTINGS,
   }));
+  const settingsStateRef = useRef(settingsState);
+  const replaceSettingsState = useCallback(
+    (next: { threadId: string | null; settings: ChatThreadSettings }) => {
+      settingsStateRef.current = next;
+      setSettingsState(next);
+    },
+    [],
+  );
   const cachedSettings = useChatStore((state) =>
     threadId ? selectThreadSettings(state, threadId) : EMPTY_SETTINGS,
   );
@@ -103,7 +111,7 @@ export function useBuiltinThreadSettings({
   // Fetch this thread's persisted selection.
   useEffect(() => {
     if (!enabled || !threadId) {
-      setSettingsState({
+      replaceSettingsState({
         threadId: threadId ?? null,
         settings: EMPTY_SETTINGS,
       });
@@ -111,7 +119,7 @@ export function useBuiltinThreadSettings({
       return;
     }
     const restored = selectThreadSettings(useChatStore.getState(), threadId);
-    setSettingsState({ threadId, settings: restored });
+    replaceSettingsState({ threadId, settings: restored });
     // Before first send there is no durable server record. The local thread
     // cache is authoritative and is carried on the first message.
     if (!threadHasMessages) {
@@ -126,7 +134,7 @@ export function useBuiltinThreadSettings({
         // Skip if the thread/enable changed, or the user picked a value
         // after this fetch started — the local choice wins (P1-2).
         if (cancelled || mutationGenRef.current !== genAtStart) return;
-        setSettingsState({ threadId, settings: next });
+        replaceSettingsState({ threadId, settings: next });
       })
       .catch(() => {
         // Keep the restored cache (or a local pick that bumped the generation).
@@ -137,7 +145,7 @@ export function useBuiltinThreadSettings({
     return () => {
       cancelled = true;
     };
-  }, [enabled, threadId, canvasId, threadHasMessages]);
+  }, [enabled, threadId, canvasId, threadHasMessages, replaceSettingsState]);
 
   // Mirror the current selection into the owning thread so the send path can
   // carry it on the request (applies a pre-first-message pick on thread
@@ -156,6 +164,24 @@ export function useBuiltinThreadSettings({
     );
   }, [enabled, threadId, settings, setThreadSettings]);
 
+  const updateLocalSettings = useCallback(
+    (
+      update: (current: ChatThreadSettings) => ChatThreadSettings,
+    ): ChatThreadSettings | null => {
+      if (!threadId) return null;
+      const current = settingsStateRef.current;
+      const previous =
+        current.threadId === threadId
+          ? current.settings
+          : selectThreadSettings(useChatStore.getState(), threadId);
+      const nextSettings = update(previous);
+      replaceSettingsState({ threadId, settings: nextSettings });
+      setThreadSettings(threadId, nextSettings);
+      return nextSettings;
+    },
+    [threadId, replaceSettingsState, setThreadSettings],
+  );
+
   const selectModel = useCallback(
     async (modelId: string) => {
       if (!threadId) return;
@@ -165,18 +191,16 @@ export function useBuiltinThreadSettings({
       // honour (off/absent stay), so the UI never shows a stale effort.
       const nextEfforts =
         models.find((m) => m.id === modelId)?.reasoningEfforts ?? [];
-      const nextSettings = {
-        ...settings,
+      updateLocalSettings((current) => ({
+        ...current,
         modelId,
         reasoningEffort:
-          settings.reasoningEffort &&
-          settings.reasoningEffort !== 'off' &&
-          !nextEfforts.includes(settings.reasoningEffort)
+          current.reasoningEffort &&
+          current.reasoningEffort !== 'off' &&
+          !nextEfforts.includes(current.reasoningEffort)
             ? null
-            : settings.reasoningEffort,
-      };
-      setSettingsState({ threadId, settings: nextSettings });
-      setThreadSettings(threadId, nextSettings);
+            : current.reasoningEffort,
+      }));
       // No persisted record yet → hold locally; the first message carries
       // it (skip the POST so nothing 404s).
       if (!threadHasMessages) return;
@@ -189,7 +213,7 @@ export function useBuiltinThreadSettings({
         // Adopt the server's canonical (clamped) values, unless the user
         // changed something while the request was in flight.
         if (mutationGenRef.current === gen) {
-          setSettingsState({ threadId, settings: corrected });
+          replaceSettingsState({ threadId, settings: corrected });
         }
       } catch {
         // Keep the optimistic value; a genuinely bad value is corrected by
@@ -201,8 +225,8 @@ export function useBuiltinThreadSettings({
       canvasId,
       threadHasMessages,
       models,
-      settings,
-      setThreadSettings,
+      updateLocalSettings,
+      replaceSettingsState,
     ],
   );
 
@@ -210,9 +234,7 @@ export function useBuiltinThreadSettings({
     async (reasoningEffort: string) => {
       if (!threadId) return;
       mutationGenRef.current += 1;
-      const nextSettings = { ...settings, reasoningEffort };
-      setSettingsState({ threadId, settings: nextSettings });
-      setThreadSettings(threadId, nextSettings);
+      updateLocalSettings((current) => ({ ...current, reasoningEffort }));
       if (!threadHasMessages) return;
       try {
         await setChatThreadReasoningEffort(
@@ -224,7 +246,7 @@ export function useBuiltinThreadSettings({
         // Keep the optimistic value; carried on the next send.
       }
     },
-    [threadId, canvasId, threadHasMessages, settings, setThreadSettings],
+    [threadId, canvasId, threadHasMessages, updateLocalSettings],
   );
 
   // The effective model id: the per-thread override, else the global default.

--- a/apps/web/src/hooks/useBuiltinThreadSettings.ts
+++ b/apps/web/src/hooks/useBuiltinThreadSettings.ts
@@ -165,23 +165,18 @@ export function useBuiltinThreadSettings({
       // honour (off/absent stay), so the UI never shows a stale effort.
       const nextEfforts =
         models.find((m) => m.id === modelId)?.reasoningEfforts ?? [];
-      setSettingsState((current) => {
-        const prior =
-          current.threadId === threadId ? current.settings : cachedSettings;
-        return {
-          threadId,
-          settings: {
-            ...prior,
-            modelId,
-            reasoningEffort:
-              prior.reasoningEffort &&
-              prior.reasoningEffort !== 'off' &&
-              !nextEfforts.includes(prior.reasoningEffort)
-                ? null
-                : prior.reasoningEffort,
-          },
-        };
-      });
+      const nextSettings = {
+        ...settings,
+        modelId,
+        reasoningEffort:
+          settings.reasoningEffort &&
+          settings.reasoningEffort !== 'off' &&
+          !nextEfforts.includes(settings.reasoningEffort)
+            ? null
+            : settings.reasoningEffort,
+      };
+      setSettingsState({ threadId, settings: nextSettings });
+      setThreadSettings(threadId, nextSettings);
       // No persisted record yet → hold locally; the first message carries
       // it (skip the POST so nothing 404s).
       if (!threadHasMessages) return;
@@ -201,22 +196,23 @@ export function useBuiltinThreadSettings({
         // the next settings fetch.
       }
     },
-    [threadId, canvasId, threadHasMessages, models, cachedSettings],
+    [
+      threadId,
+      canvasId,
+      threadHasMessages,
+      models,
+      settings,
+      setThreadSettings,
+    ],
   );
 
   const selectReasoningEffort = useCallback(
     async (reasoningEffort: string) => {
       if (!threadId) return;
       mutationGenRef.current += 1;
-      setSettingsState((current) => ({
-        threadId,
-        settings: {
-          ...(current.threadId === threadId
-            ? current.settings
-            : cachedSettings),
-          reasoningEffort,
-        },
-      }));
+      const nextSettings = { ...settings, reasoningEffort };
+      setSettingsState({ threadId, settings: nextSettings });
+      setThreadSettings(threadId, nextSettings);
       if (!threadHasMessages) return;
       try {
         await setChatThreadReasoningEffort(
@@ -228,7 +224,7 @@ export function useBuiltinThreadSettings({
         // Keep the optimistic value; carried on the next send.
       }
     },
-    [threadId, canvasId, threadHasMessages, cachedSettings],
+    [threadId, canvasId, threadHasMessages, settings, setThreadSettings],
   );
 
   // The effective model id: the per-thread override, else the global default.

--- a/apps/web/src/store/previewWorkspace/actions.ts
+++ b/apps/web/src/store/previewWorkspace/actions.ts
@@ -62,8 +62,8 @@ export function openChat(): string {
 }
 
 export function closeActivePreviewNode(): void {
-  const workspace = usePreviewWorkspaceStore.getState();
-  const activeTab = selectActiveTab(workspace);
+  const preview = usePreviewWorkspaceStore.getState();
+  const activeTab = selectActiveTab(preview);
   if (!activeTab) return;
   const target = activeTab?.target;
   if (target?.kind !== 'node') return;
@@ -71,8 +71,9 @@ export function closeActivePreviewNode(): void {
   const node = useCanvasStore
     .getState()
     .nodes.find((candidate) => candidate.id === target.nodeId);
-  if (node?.type === 'note' || node?.type === 'text') {
-    settleNodePreprocess(node.id);
-  }
-  workspace.closeTab(activeTab.id);
+  preview.closeTab(activeTab.id, () => {
+    if (node?.type === 'note' || node?.type === 'text') {
+      settleNodePreprocess(node.id);
+    }
+  });
 }

--- a/apps/web/src/store/previewWorkspace/model.test.ts
+++ b/apps/web/src/store/previewWorkspace/model.test.ts
@@ -353,6 +353,24 @@ describe('moveTab', () => {
     expect(moved.groups[0].activeTabId).toBe('t1');
   });
 
+  it('replaces the destination transient tab with the moved one', () => {
+    const first = open(emptyWorkspace(), node('a'), 't1', {
+      transient: true,
+    }).workspace;
+    const split = open(first, node('b'), 't2', {
+      transient: true,
+      openToSide: true,
+    }).workspace;
+    const sideGroupId = split.groups[1].id;
+
+    const moved = moveTab(split, 't1', { groupId: sideGroupId });
+
+    expect(moved.groups).toHaveLength(1);
+    expect(moved.tabs['t1'].transient).toBe(true);
+    expect(moved.tabs['t2']).toBeUndefined();
+    expect(moved.groups[0].tabIds).toEqual(['t1']);
+  });
+
   it('collapses the source group when its last tab leaves', () => {
     const a = open(emptyWorkspace(), node('a'), 't1').workspace;
     const b = open(a, node('b'), 't2', { openToSide: true }).workspace;
@@ -378,6 +396,22 @@ describe('mergeGroups', () => {
     expect(merged.groups).toHaveLength(1);
     expect(merged.groups[0].tabIds).toEqual(['t1', 't2']);
     expect(merged.activeGroupId).toBe('g1');
+  });
+
+  it('drops older transient tabs when merging groups', () => {
+    const first = open(emptyWorkspace(), node('a'), 't1', {
+      transient: true,
+    }).workspace;
+    const split = open(first, node('b'), 't2', {
+      transient: true,
+      openToSide: true,
+    }).workspace;
+
+    const merged = mergeGroups(split);
+
+    expect(merged.tabs['t1']).toBeUndefined();
+    expect(merged.tabs['t2'].transient).toBe(true);
+    expect(merged.groups[0].tabIds).toEqual(['t2']);
   });
 
   it('is a no-op with a single group', () => {

--- a/apps/web/src/store/previewWorkspace/model.ts
+++ b/apps/web/src/store/previewWorkspace/model.ts
@@ -201,6 +201,50 @@ export function promoteTab(
   };
 }
 
+/** Repairs the one-transient-tab-per-group invariant by dropping older slots. */
+export function repairTransientTabs(
+  workspace: CanvasPreviewWorkspace,
+  preferredTabId?: string,
+): CanvasPreviewWorkspace {
+  let tabs = workspace.tabs;
+  let groups = workspace.groups;
+
+  for (const group of groups) {
+    const transientIds = group.tabIds.filter((tabId) => tabs[tabId]?.transient);
+    if (transientIds.length <= 1) continue;
+
+    const keeper =
+      preferredTabId && transientIds.includes(preferredTabId)
+        ? preferredTabId
+        : transientIds.reduce((latestId, tabId) =>
+            tabs[tabId].lastActiveSeq > tabs[latestId].lastActiveSeq
+              ? tabId
+              : latestId,
+          );
+
+    const removedIds = new Set(
+      transientIds.filter((tabId) => tabId !== keeper),
+    );
+    if (tabs === workspace.tabs) tabs = { ...workspace.tabs };
+    for (const tabId of removedIds) delete tabs[tabId];
+
+    groups = groups.map((candidate) =>
+      candidate.id === group.id
+        ? {
+            ...candidate,
+            tabIds: candidate.tabIds.filter((tabId) => !removedIds.has(tabId)),
+            activeTabId:
+              candidate.activeTabId && removedIds.has(candidate.activeTabId)
+                ? keeper
+                : candidate.activeTabId,
+          }
+        : candidate,
+    );
+  }
+
+  return tabs === workspace.tabs ? workspace : { ...workspace, tabs, groups };
+}
+
 function ensureSideGroup(
   workspace: CanvasPreviewWorkspace,
   fromGroupId: string,
@@ -241,7 +285,7 @@ export function openTarget(
     ? requestedGroupId
     : workspace.activeGroupId;
 
-  let next = workspace;
+  let next = repairTransientTabs(workspace);
   let destinationGroupId = baseGroupId;
 
   if (options.openToSide) {
@@ -423,7 +467,10 @@ export function moveTab(
     return g;
   });
 
-  return withoutEmptyGroups({ ...workspace, groups });
+  return repairTransientTabs(
+    withoutEmptyGroups({ ...workspace, groups }),
+    tabId,
+  );
 }
 
 /** Folds every tab back into the first group. */
@@ -440,12 +487,12 @@ export function mergeGroups(
       first.activeTabId ?? rest.find((g) => g.activeTabId)?.activeTabId ?? null,
   };
 
-  return {
+  return repairTransientTabs({
     ...workspace,
     groups: [merged],
     activeGroupId: merged.id,
     splitRatio: DEFAULT_SPLIT_RATIO,
-  };
+  });
 }
 
 export function setActiveGroup(
@@ -505,5 +552,5 @@ export function validateWorkspace(
       : groups[0].id,
   });
 
-  return next;
+  return repairTransientTabs(next);
 }

--- a/apps/web/src/store/previewWorkspace/persistence.test.ts
+++ b/apps/web/src/store/previewWorkspace/persistence.test.ts
@@ -184,6 +184,39 @@ describe('defensive parsing', () => {
     expect(restored?.splitRatio).toBe(0.5);
   });
 
+  it('drops older duplicate transient tabs within one group', () => {
+    testStorage.storage.setItem(
+      KEY,
+      JSON.stringify({
+        version: 1,
+        workspace: {
+          tabs: {
+            t1: {
+              id: 't1',
+              target: node('a'),
+              transient: true,
+              lastActiveSeq: 1,
+            },
+            t2: {
+              id: 't2',
+              target: node('b'),
+              transient: true,
+              lastActiveSeq: 2,
+            },
+          },
+          groups: [{ id: 'g1', tabIds: ['t1', 't2'], activeTabId: 't2' }],
+          activeGroupId: 'g1',
+          activationSeq: 2,
+        },
+      }),
+    );
+
+    const restored = readWorkspace(CANVAS);
+    expect(restored?.tabs.t1).toBeUndefined();
+    expect(restored?.tabs.t2.transient).toBe(true);
+    expect(restored?.groups[0].tabIds).toEqual(['t2']);
+  });
+
   it('drops a tab claimed by two groups and discards orphans', () => {
     testStorage.storage.setItem(
       KEY,

--- a/apps/web/src/store/previewWorkspace/persistence.ts
+++ b/apps/web/src/store/previewWorkspace/persistence.ts
@@ -16,6 +16,7 @@ import {
   MAX_PREVIEW_GROUPS,
   createEmptyWorkspace,
   findTabByTarget,
+  repairTransientTabs,
   type CanvasPreviewWorkspace,
   type PreviewGroup,
   type PreviewTab,
@@ -198,7 +199,13 @@ function parseWorkspace(
         ? source.activationSeq
         : Math.max(0, ...Object.values(tabs).map((t) => t.lastActiveSeq));
 
-    return { tabs, groups, activeGroupId, splitRatio, activationSeq };
+    return repairTransientTabs({
+      tabs,
+      groups,
+      activeGroupId,
+      splitRatio,
+      activationSeq,
+    });
   } catch {
     // Corrupt entries are treated as missing layout.
     return null;

--- a/apps/web/src/store/previewWorkspace/store.test.ts
+++ b/apps/web/src/store/previewWorkspace/store.test.ts
@@ -58,6 +58,8 @@ beforeEach(() => {
     workspace: createEmptyWorkspace(),
     nodeFocusRequest: null,
     nodeFocusRequestSeq: 0,
+    chatOpenRequest: null,
+    chatOpenRequestSeq: 0,
   });
 });
 
@@ -169,9 +171,11 @@ describe('actions delegate to the model', () => {
 
   it('closes a tab', () => {
     const tabId = store().openPreviewTarget(node('a'));
+    const beforeTabRemoved = vi.fn();
 
-    store().closeTab(tabId);
+    store().closeTab(tabId, beforeTabRemoved);
 
+    expect(beforeTabRemoved).toHaveBeenCalledWith(tabId);
     expect(store().workspace.tabs[tabId]).toBeUndefined();
   });
 
@@ -203,6 +207,28 @@ describe('actions delegate to the model', () => {
     expect(selectGroupOfTab(store(), tabId)).toBe(sideGroupId);
   });
 
+  it('settles and clears runtime requests for a transient removed by a move', () => {
+    const moved = store().openPreviewTarget(node('a'), { transient: true });
+    const removed = store().openPreviewTarget(node('b'), {
+      transient: true,
+      openToSide: true,
+    });
+    const sideGroupId = store().workspace.groups[1].id;
+    store().requestNodeFocus(removed);
+    store().requestChatOpen(removed, 'bottom');
+    const beforeTabRemoved = vi.fn((tabId: string) => {
+      expect(store().workspace.tabs[tabId]).toBeDefined();
+    });
+
+    store().moveTab(moved, { groupId: sideGroupId }, beforeTabRemoved);
+
+    expect(beforeTabRemoved).toHaveBeenCalledOnce();
+    expect(beforeTabRemoved).toHaveBeenCalledWith(removed);
+    expect(store().workspace.tabs[removed]).toBeUndefined();
+    expect(store().nodeFocusRequest).toBeNull();
+    expect(store().chatOpenRequest).toBeNull();
+  });
+
   it('replaces a tab target in place', () => {
     const tabId = store().openPreviewTarget(chat('thread-1'));
 
@@ -220,6 +246,25 @@ describe('actions delegate to the model', () => {
 
     expect(store().workspace.groups).toHaveLength(1);
     expect(store().workspace.groups[0].tabIds).toHaveLength(2);
+  });
+
+  it('settles and clears runtime requests for a transient removed by merge', () => {
+    const removed = store().openPreviewTarget(node('a'), { transient: true });
+    const kept = store().openPreviewTarget(node('b'), {
+      transient: true,
+      openToSide: true,
+    });
+    store().requestNodeFocus(removed);
+    store().requestChatOpen(removed, 'last-user');
+    const beforeTabRemoved = vi.fn();
+
+    store().mergeGroups(beforeTabRemoved);
+
+    expect(beforeTabRemoved).toHaveBeenCalledWith(removed);
+    expect(store().workspace.tabs[removed]).toBeUndefined();
+    expect(store().workspace.tabs[kept]).toBeDefined();
+    expect(store().nodeFocusRequest).toBeNull();
+    expect(store().chatOpenRequest).toBeNull();
   });
 
   it('sets the active group', () => {
@@ -245,6 +290,17 @@ describe('actions delegate to the model', () => {
     store().validate(new Set(['b']));
 
     expect(Object.keys(store().workspace.tabs)).toEqual([kept]);
+  });
+
+  it('clears runtime requests for tabs removed by validation', () => {
+    const removed = store().openPreviewTarget(node('a'));
+    store().requestNodeFocus(removed);
+    store().requestChatOpen(removed, 'last-user');
+
+    store().validate(new Set());
+
+    expect(store().nodeFocusRequest).toBeNull();
+    expect(store().chatOpenRequest).toBeNull();
   });
 
   it('validates nothing before a Canvas is loaded', () => {

--- a/apps/web/src/store/previewWorkspace/store.ts
+++ b/apps/web/src/store/previewWorkspace/store.ts
@@ -48,6 +48,29 @@ export type LegacyChatSeed = {
   questionNodeId?: string;
 };
 
+export type BeforePreviewTabRemoved = (tabId: string) => void;
+
+function commitWorkspace(
+  state: PreviewWorkspaceState,
+  workspace: CanvasPreviewWorkspace,
+  beforeTabRemoved?: BeforePreviewTabRemoved,
+): Partial<PreviewWorkspaceState> {
+  const removedTabIds = Object.keys(state.workspace.tabs).filter(
+    (tabId) => !workspace.tabs[tabId],
+  );
+  for (const tabId of removedTabIds) beforeTabRemoved?.(tabId);
+
+  return {
+    workspace,
+    ...(state.nodeFocusRequest && !workspace.tabs[state.nodeFocusRequest.tabId]
+      ? { nodeFocusRequest: null }
+      : {}),
+    ...(state.chatOpenRequest && !workspace.tabs[state.chatOpenRequest.tabId]
+      ? { chatOpenRequest: null }
+      : {}),
+  };
+}
+
 export type PreviewWorkspaceState = {
   /** Canvas whose layout is currently in memory; `''` before the first load. */
   canvasId: string;
@@ -77,16 +100,18 @@ export type PreviewWorkspaceState = {
   openPreviewTarget: (
     target: PreviewTarget,
     options?: OpenPreviewTargetOptions,
+    beforeTabRemoved?: BeforePreviewTabRemoved,
   ) => string;
-  closeTab: (tabId: string) => void;
+  closeTab: (tabId: string, beforeTabRemoved?: BeforePreviewTabRemoved) => void;
   activateTab: (tabId: string) => void;
   promoteTab: (tabId: string) => void;
   moveTab: (
     tabId: string,
     destination: { groupId: string; index?: number },
+    beforeTabRemoved?: BeforePreviewTabRemoved,
   ) => void;
   replaceTabTarget: (tabId: string, target: PreviewTarget) => void;
-  mergeGroups: () => void;
+  mergeGroups: (beforeTabRemoved?: BeforePreviewTabRemoved) => void;
   setActiveGroup: (groupId: string) => void;
   setSplitRatio: (ratio: number) => void;
   requestNodeFocus: (tabId: string) => void;
@@ -129,25 +154,18 @@ export const usePreviewWorkspaceStore = create<PreviewWorkspaceState>(
       if (canvasId) writeWorkspace(canvasId, workspace);
     },
 
-    openPreviewTarget: (target, options) => {
-      const opened = openTarget(get().workspace, target, options);
+    openPreviewTarget: (target, options, beforeTabRemoved) => {
+      const state = get();
+      const opened = openTarget(state.workspace, target, options);
       if (!opened.tabId) return '';
-      set({ workspace: opened.workspace });
+      set(commitWorkspace(state, opened.workspace, beforeTabRemoved));
       return opened.tabId;
     },
 
-    closeTab: (tabId) => {
+    closeTab: (tabId, beforeTabRemoved) => {
       const state = get();
       const workspace = closeTab(state.workspace, tabId);
-      set({
-        workspace,
-        ...(state.nodeFocusRequest?.tabId === tabId
-          ? { nodeFocusRequest: null }
-          : {}),
-        ...(state.chatOpenRequest?.tabId === tabId
-          ? { chatOpenRequest: null }
-          : {}),
-      });
+      set(commitWorkspace(state, workspace, beforeTabRemoved));
     },
 
     activateTab: (tabId) =>
@@ -156,14 +174,21 @@ export const usePreviewWorkspaceStore = create<PreviewWorkspaceState>(
     promoteTab: (tabId) =>
       set({ workspace: promoteTab(get().workspace, tabId) }),
 
-    moveTab: (tabId, destination) =>
-      set({ workspace: moveTab(get().workspace, tabId, destination) }),
+    moveTab: (tabId, destination, beforeTabRemoved) => {
+      const state = get();
+      const workspace = moveTab(state.workspace, tabId, destination);
+      set(commitWorkspace(state, workspace, beforeTabRemoved));
+    },
 
     replaceTabTarget: (tabId, target) => {
       set({ workspace: replaceTabTarget(get().workspace, tabId, target) });
     },
 
-    mergeGroups: () => set({ workspace: mergeGroups(get().workspace) }),
+    mergeGroups: (beforeTabRemoved) => {
+      const state = get();
+      const workspace = mergeGroups(state.workspace);
+      set(commitWorkspace(state, workspace, beforeTabRemoved));
+    },
 
     setActiveGroup: (groupId) =>
       set({ workspace: setActiveGroup(get().workspace, groupId) }),
@@ -206,10 +231,11 @@ export const usePreviewWorkspaceStore = create<PreviewWorkspaceState>(
       ),
 
     validate: (liveNodeIds) => {
-      const { canvasId, workspace } = get();
+      const state = get();
+      const { canvasId, workspace } = state;
       if (!canvasId) return;
       const validated = validateWorkspace(workspace, canvasId, liveNodeIds);
-      set({ workspace: validated });
+      set(commitWorkspace(state, validated));
     },
   }),
 );

--- a/docs/architecture/preview-workspace.md
+++ b/docs/architecture/preview-workspace.md
@@ -100,7 +100,7 @@ Pointer dragging keeps a faded source placeholder in the tab strip, portals a la
 
 Closing an active tab selects the nearest remaining tab in the same group. Moving or closing the final tab in a secondary group removes that group. The workspace keeps one empty primary group as its valid empty state.
 
-A transient tab is one reusable inspection slot per group. Opening another transient target replaces that slot; using its Pin action, double-clicking the tab, or committing a persistent mutation through its renderer promotes it in place. Moving a transient tab into a side group does not promote it.
+A transient tab is one reusable inspection slot per group. Opening another transient target replaces that slot; using its Pin action, double-clicking the tab, or committing a persistent mutation through its renderer promotes it in place. Moving a transient tab into a side group does not promote the moved tab; if that group already has a transient slot, the moved tab replaces the existing disposable slot. Merging groups keeps the most recently active transient slot and drops any older transient slot. Runtime topology changes report every implicitly removed tab before committing the new workspace so mounted authored editors can settle through the same lifecycle boundary as an explicit close; the store then clears tab-addressed focus and opening requests atomically with the topology update. Persistence repair has no mounted editor and only repairs the stored topology.
 
 Permanent tabs are never closed automatically. A group may retain any number of permanent tabs; users close them explicitly, while transient browsing continues to reuse the group's inspection slot.
 
@@ -124,7 +124,7 @@ The current Canvas layout is written synchronously before switching Canvas and b
 
 A capped MRU index retains workspace records for at most 50 Canvases. Evicting an old layout is non-destructive because the record contains presentation topology only.
 
-Persisted input is parsed defensively. Invalid targets, dangling tab IDs, duplicate group references, invalid active IDs, excess groups, and malformed split values are dropped or repaired without preventing the remaining layout from loading.
+Persisted input is parsed defensively. Invalid targets, dangling tab IDs, duplicate group references, invalid active IDs, excess groups, duplicate transient slots within one group, and malformed split values are dropped or repaired without preventing the remaining layout from loading. Duplicate transient slots keep the most recently active slot and drop the older disposable slots.
 
 After a command deletes nodes, the web post-effect validates the workspace against the committed live node IDs. Tabs targeting deleted nodes are removed and active IDs or empty groups are repaired by `validateWorkspace`.
 

--- a/docs/architecture/preview-workspace.md
+++ b/docs/architecture/preview-workspace.md
@@ -68,7 +68,7 @@ Titles are derived at render time. Node tabs use the current node label; Chat ta
 
 Open to Side moves the existing semantic target into the other group instead of duplicating it and preserves whether the tab is transient or permanent. Saving an unbound Chat as a Question replaces that tab's target in place, preserving tab identity, position, messages, and draft continuity.
 
-Canvas node double-clicks, search results, and connected-node navigation open transiently. Question compose or replay and new Chat opens are permanent.
+Canvas node double-clicks, Question toolbar compose or replay actions, search results, and connected-node navigation open transiently. New Chat opens are permanent.
 
 ## 4. Rendering and Chat sessions
 


### PR DESCRIPTION
This pull request introduces improvements to the handling of "transient" tabs in the Preview Workspace and enhances the consistency and reliability of thread settings in the chat UI. The most significant changes ensure that only one transient tab exists per group, add support for opening question conversations and compose views transiently, and update thread settings optimistically before the first message is sent. These changes are covered by new and updated tests to ensure correct behavior.

**Transient tab management and Preview Workspace behavior:**

* Added a new `repairTransientTabs` function in `model.ts` to enforce the invariant that only one transient tab can exist per group, removing older transient tabs as necessary. This function is now called in `openTarget`, `moveTab`, and `mergeGroups` to maintain consistency when opening, moving, or merging tabs/groups. [[1]](diffhunk://#diff-61000134f8cc1488070ca95ce6cc97d01d03859c2afd92c5e91175188b3396c0R204-R247) [[2]](diffhunk://#diff-61000134f8cc1488070ca95ce6cc97d01d03859c2afd92c5e91175188b3396c0L244-R288) [[3]](diffhunk://#diff-61000134f8cc1488070ca95ce6cc97d01d03859c2afd92c5e91175188b3396c0L426-R473) [[4]](diffhunk://#diff-61000134f8cc1488070ca95ce6cc97d01d03859c2afd92c5e91175188b3396c0L443-R495)
* Updated `PreviewWorkspace.tsx` to pass the `settleTab` callback to tab-closing, moving, and re-opening actions, ensuring proper cleanup and state updates for transient tabs. [[1]](diffhunk://#diff-4c5a3a44baa5c6229a7db4a27f757e52d84cbba81afcb0ef217a5eb691383890L264-R264) [[2]](diffhunk://#diff-4c5a3a44baa5c6229a7db4a27f757e52d84cbba81afcb0ef217a5eb691383890L279-R285) [[3]](diffhunk://#diff-4c5a3a44baa5c6229a7db4a27f757e52d84cbba81afcb0ef217a5eb691383890L340-R343)
* Enhanced tests in `model.test.ts` to verify correct behavior when moving tabs and merging groups with transient tabs. [[1]](diffhunk://#diff-0173381ec085a2df1e6e3a40714c40260cb5183f03fa3b8b3a081e19246bcf99R356-R373) [[2]](diffhunk://#diff-0173381ec085a2df1e6e3a40714c40260cb5183f03fa3b8b3a081e19246bcf99R401-R416)

**Question node and conversation opening:**

* Modified `QuestionNode.tsx` to support opening question conversations and compose views transiently, by passing a `transient` flag through the relevant callbacks and UI actions. [[1]](diffhunk://#diff-9b97999942257f6449e5fff0e06ebe510b1f2106dc34f6ac02d643175a00b056L177-R178) [[2]](diffhunk://#diff-9b97999942257f6449e5fff0e06ebe510b1f2106dc34f6ac02d643175a00b056R196-R203) [[3]](diffhunk://#diff-9b97999942257f6449e5fff0e06ebe510b1f2106dc34f6ac02d643175a00b056L209-R221) [[4]](diffhunk://#diff-9b97999942257f6449e5fff0e06ebe510b1f2106dc34f6ac02d643175a00b056R234-L230) [[5]](diffhunk://#diff-9b97999942257f6449e5fff0e06ebe510b1f2106dc34f6ac02d643175a00b056L243-R253) [[6]](diffhunk://#diff-9b97999942257f6449e5fff0e06ebe510b1f2106dc34f6ac02d643175a00b056L265-R280)
* Updated `questionCompose.ts` to accept and forward the `transient` option when opening preview nodes for question conversations or compose views. [[1]](diffhunk://#diff-b387a3e8924dff063f42ab279dd1ba3cbef9aec2c9a93a77247aecc9e1245337R50-R56) [[2]](diffhunk://#diff-b387a3e8924dff063f42ab279dd1ba3cbef9aec2c9a93a77247aecc9e1245337R70-R73)
* Added tests to ensure that opening a question conversation or compose view transiently sets the correct tab state. [[1]](diffhunk://#diff-844e1c2068881fdff741387cf6a06d213ae0656442f6dbbc990597315774c78bR64-R74) [[2]](diffhunk://#diff-844e1c2068881fdff741387cf6a06d213ae0656442f6dbbc990597315774c78bR89-R97)

**Thread settings and chat UI improvements:**

* Updated `useBuiltinThreadSettings.ts` to optimistically update the thread settings cache before the first message is sent, ensuring the UI reflects the latest selection immediately, and added a test for this behavior. [[1]](diffhunk://#diff-e9690d91a42cb9c345a330e54900901b051002335c61d90a567fa5625062b98aL168-R179) [[2]](diffhunk://#diff-e9690d91a42cb9c345a330e54900901b051002335c61d90a567fa5625062b98aL204-R215) [[3]](diffhunk://#diff-e9690d91a42cb9c345a330e54900901b051002335c61d90a567fa5625062b98aL231-R227) [[4]](diffhunk://#diff-6c6b5c2321caae11780cad2f7842d528d7dfd2ef8b7fd0e4405ea82280ae1719R29-R34) [[5]](diffhunk://#diff-6c6b5c2321caae11780cad2f7842d528d7dfd2ef8b7fd0e4405ea82280ae1719L40-R67) [[6]](diffhunk://#diff-6c6b5c2321caae11780cad2f7842d528d7dfd2ef8b7fd0e4405ea82280ae1719L80-R126)

**Miscellaneous:**

* Fixed `closeActivePreviewNode` in `actions.ts` to ensure that tab closing logic is properly encapsulated and that node preprocessing is performed as needed.

These changes collectively improve the reliability and user experience of the Preview Workspace and chat features, particularly regarding transient tab management and immediate feedback in thread settings.