### PR TITLE
fix(desktop): auto-open DevTools only for UI dev, not every unpacked run

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1086,7 +1086,15 @@ function createWindow(port: number): void {
     }
   });
 
-  if (IS_DEV) {
+  // Auto-open DevTools only for real UI development (Vite HMR via
+  // dev:desktop) or when explicitly requested with HUABU_DEVTOOLS=1.
+  // Other unpacked runs (e.g. `start:desktop`, or an unpacked production
+  // build run straight from source) behave like production. F12 /
+  // Ctrl+Shift+I still toggle them at any time (see above).
+  if (
+    IS_DEV &&
+    (process.env.WEB_DEV_SERVER_URL || process.env.HUABU_DEVTOOLS === '1')
+  ) {
     mainWindow.webContents.openDevTools();
   }
 


### PR DESCRIPTION
# fix(desktop): auto-open DevTools only for UI dev, not every unpacked run

## Summary

DevTools currently auto-open on **every** run of the desktop app that isn't a packaged build. This PR narrows that to the one scenario where auto-opening actually helps — renderer development with Vite HMR — and adds an explicit opt-out for everything else.

## The problem

The trigger for auto-opening DevTools is `IS_DEV`, which is defined as:

```ts
const IS_DEV = !app.isPackaged;
```

`!app.isPackaged` means "not an electron-builder artifact" — but it does **not** mean "the user is developing the UI". Several legitimate, non-development ways of running Huabu fall into this bucket and get DevTools forced open at launch:

1. **`pnpm start:desktop`** — the script's name and documented semantics are "build everything, then run the desktop app as a user would". Yet because it ends in `pnpm --filter @huabu/desktop dev` (which spawns an unpacked Electron), DevTools pop up. A *start* script shouldn't put a debugger in your face.

2. **An unpacked production build run straight from source.** If someone builds the app (`pnpm run build:desktop` steps minus `electron-builder`) and runs `electron .` directly — for example because packaging isn't available or fails on their platform — every launch opens DevTools. This is a consumption scenario, not a development scenario.

3. **Any other unpacked Electron invocation**, such as CI smoke tests or sandbox-restricted environments that bypass electron-builder.

In all of these cases the main application window's first paint is immediately covered by DevTools, and the user has to close it by hand — every single launch.

### What the behavior should be

Auto-opening DevTools is genuinely useful in exactly one situation: **UI/renderer development**, where you're iterating on the web frontend inside Electron and want the inspector available immediately. The desktop dev orchestrator (`pnpm dev:desktop`) already has a precise, unambiguous signal for this: it sets `WEB_DEV_SERVER_URL` to hand the renderer to Vite with HMR.

## The fix

DevTools now auto-open only when either:

- **`WEB_DEV_SERVER_URL` is set** — i.e. the renderer is being served by Vite via the `dev:desktop` orchestrator. UI developers see **no change** in behavior.
- **`HUABU_DEVTOOLS=1` is set** — an explicit override for anyone who wants the old behavior in any other unpacked scenario.

F12 / Ctrl+Shift+I still toggle DevTools at any time (existing shortcut handling is untouched).

```ts
if (
  IS_DEV &&
  (process.env.WEB_DEV_SERVER_URL || process.env.HUABU_DEVTOOLS === '1')
) {
  mainWindow.webContents.openDevTools();
}
```

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| `pnpm dev:desktop` (Vite HMR, real UI dev) | opens | **opens** (unchanged) |
| `pnpm start:desktop` (build, then run) | opens | doesn't |
| unpacked production build via `electron .` | opens | doesn't |
| packaged app (`app.isPackaged`) | doesn't | doesn't (unchanged) |
| any unpacked run + `HUABU_DEVTOOLS=1` | — | opens |

## Testing

- `tsc --noEmit` passes for `@huabu/desktop`.
- Verified manually: unpacked production build launches with a clean window; setting `WEB_DEV_SERVER_URL` restores auto-open; `HUABU_DEVTOOLS=1` forces auto-open; F12 toggles as before.