### PR TITLE
Support browser new-tab gestures for Space navigation

### DIFF
--- a/apps/web/src/components/Common/DropdownMenu.tsx
+++ b/apps/web/src/components/Common/DropdownMenu.tsx
@@ -11,12 +11,14 @@ import {
   type ReactElement,
   type ReactNode,
 } from 'react';
+import { Link } from 'react-router-dom';
 
 import { Button } from './Button';
 import { cn } from './cn';
 import { Popover } from './Popover';
 
 import type { ButtonHTMLAttributes } from 'react';
+import type { LinkProps } from 'react-router-dom';
 
 // ─── DropdownMenuItem ─────────────────────────────────────────────────────────
 
@@ -32,6 +34,27 @@ type DropdownMenuItemProps = {
   ButtonHTMLAttributes<HTMLButtonElement>,
   'children' | 'className' | 'role'
 >;
+
+type DropdownMenuItemContentProps = Pick<
+  DropdownMenuItemProps,
+  'icon' | 'children' | 'shortcut' | 'trailing'
+>;
+
+const DropdownMenuItemContent: React.FC<DropdownMenuItemContentProps> = ({
+  icon,
+  children,
+  shortcut,
+  trailing,
+}) => (
+  <>
+    {icon && <span className="text-fg-subtle shrink-0">{icon}</span>}
+    <span className="flex-1 text-left">{children}</span>
+    {shortcut && (
+      <span className="text-fg-subtle ml-4 shrink-0 text-xs">{shortcut}</span>
+    )}
+    {trailing}
+  </>
+);
 
 /**
  * A single item inside a `DropdownMenu`. Uses `Button` with ghost variant as its base.
@@ -54,13 +77,50 @@ export const DropdownMenuItem: React.FC<DropdownMenuItemProps> = ({
     )}
     {...props}
   >
-    {icon && <span className="text-fg-subtle shrink-0">{icon}</span>}
-    <span className="flex-1 text-left">{children}</span>
-    {shortcut && (
-      <span className="text-fg-subtle ml-4 shrink-0 text-xs">{shortcut}</span>
-    )}
-    {trailing}
+    <DropdownMenuItemContent
+      icon={icon}
+      shortcut={shortcut}
+      trailing={trailing}
+    >
+      {children}
+    </DropdownMenuItemContent>
   </Button>
+);
+
+type DropdownMenuLinkProps = DropdownMenuItemContentProps &
+  Omit<LinkProps, 'children' | 'className' | 'role'> & {
+    className?: string;
+  };
+
+/**
+ * A router link presented as a menu item. Native anchor semantics preserve
+ * browser new-tab gestures while React Router handles an ordinary click.
+ */
+export const DropdownMenuLink: React.FC<DropdownMenuLinkProps> = ({
+  icon,
+  children,
+  shortcut,
+  trailing,
+  className,
+  ...props
+}) => (
+  <Link
+    role="menuitem"
+    className={cn(
+      'text-fg-muted hover:bg-hover flex w-full cursor-pointer items-center justify-start gap-2 rounded-none border-none bg-transparent px-3 py-1.5 text-xs transition-colors',
+      '[&_svg]:shrink-0',
+      className,
+    )}
+    {...props}
+  >
+    <DropdownMenuItemContent
+      icon={icon}
+      shortcut={shortcut}
+      trailing={trailing}
+    >
+      {children}
+    </DropdownMenuItemContent>
+  </Link>
 );
 
 // ─── DropdownMenu (container) ─────────────────────────────────────────────────

--- a/apps/web/src/components/Panels/Header/AppMenu.test.tsx
+++ b/apps/web/src/components/Panels/Header/AppMenu.test.tsx
@@ -3,17 +3,15 @@
 
 import { act, type ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AppMenu } from './AppMenu';
 
+import type * as DropdownMenuExports from '../../Common/DropdownMenu';
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
-}));
-
-vi.mock('react-router-dom', () => ({
-  useLocation: () => ({ pathname: '/canvas/c1' }),
-  useNavigate: () => vi.fn(),
 }));
 
 vi.mock('../../../config/handbook', () => ({ openUserHandbook: vi.fn() }));
@@ -65,11 +63,29 @@ vi.mock('../../../store/workspaceStore', () => ({
       worldEnabled: false,
     }),
 }));
-vi.mock('../../Common/DropdownMenu', () => ({
-  DropdownMenu: ({ trigger }: { trigger: ReactNode }) => trigger,
-  DropdownMenuItem: () => null,
-  DropdownMenuSubmenu: () => null,
-}));
+vi.mock('../../Common/DropdownMenu', async (importOriginal) => {
+  const actual = await importOriginal<typeof DropdownMenuExports>();
+  return {
+    ...actual,
+    DropdownMenu: ({
+      trigger,
+      children,
+    }: {
+      trigger: ReactNode;
+      children: ReactNode;
+    }) => (
+      <>
+        {trigger}
+        {children}
+      </>
+    ),
+    DropdownMenuSubmenu: () => null,
+  };
+});
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
 
 let root: Root | undefined;
 let container: HTMLDivElement | undefined;
@@ -87,10 +103,37 @@ describe('AppMenu', () => {
     document.body.appendChild(container);
     root = createRoot(container);
 
-    act(() => root?.render(<AppMenu />));
+    act(() =>
+      root?.render(
+        <MemoryRouter initialEntries={['/canvas/c1']}>
+          <AppMenu />
+        </MemoryRouter>,
+      ),
+    );
 
     const fileInput =
       container.querySelector<HTMLInputElement>('input[type="file"]');
     expect(fileInput?.name).toBe('space-import-archive');
+  });
+
+  it('renders Back to Space list as a native router link', () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() =>
+      root?.render(
+        <MemoryRouter initialEntries={['/canvas/c1']}>
+          <AppMenu />
+        </MemoryRouter>,
+      ),
+    );
+
+    const link = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>('a[role="menuitem"]'),
+    ).find((candidate) =>
+      candidate.textContent?.includes('canvasPage.backToList'),
+    );
+    expect(link?.getAttribute('href')).toBe('/spaces');
   });
 });

--- a/apps/web/src/components/Panels/Header/AppMenu.tsx
+++ b/apps/web/src/components/Panels/Header/AppMenu.tsx
@@ -25,6 +25,7 @@ import { formatShortcut } from '../../../utils/platform';
 import {
   DropdownMenu,
   DropdownMenuItem,
+  DropdownMenuLink,
   DropdownMenuSubmenu,
 } from '../../Common/DropdownMenu';
 
@@ -139,9 +140,9 @@ export const AppMenu: React.FC<AppMenuProps> = ({
         )}
         {showCanvasListLink && (
           <>
-            <DropdownMenuItem onClick={runAndClose(() => navigate('/spaces'))}>
+            <DropdownMenuLink to="/spaces" onClick={() => setIsOpen(false)}>
               {t('canvasPage.backToList')}
-            </DropdownMenuItem>
+            </DropdownMenuLink>
             <div className="border-edge-default my-1 border-t" />
           </>
         )}

--- a/apps/web/src/pages/CanvasListPage.test.tsx
+++ b/apps/web/src/pages/CanvasListPage.test.tsx
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import CanvasListPage from './CanvasListPage';
+
+import type { ReactNode } from 'react';
+
+const setCanvasCount = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  Trans: ({ i18nKey }: { i18nKey: string }) => i18nKey,
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+vi.mock('../api/canvas', () => ({
+  deleteCanvasById: vi.fn(),
+  exportCanvas: vi.fn(),
+  listCanvases: vi.fn().mockResolvedValue({
+    canvases: [
+      {
+        canvasId: 'space-1',
+        title: 'Space One',
+        nodeCount: 2,
+        updatedAt: 0,
+      },
+    ],
+  }),
+}));
+
+vi.mock('../components/Common/Modal', () => ({
+  Modal: () => null,
+}));
+
+vi.mock('../components/Common/Loading', () => ({
+  Loading: () => <div>loading</div>,
+}));
+
+vi.mock('../components/Common/Tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock('../components/Panels/Header/Header', () => ({
+  Header: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock('../hooks/useCanvasActions', () => ({
+  useCanvasActions: () => ({
+    create: vi.fn(),
+    fileInputRef: { current: null },
+    isCreating: false,
+    isImporting: false,
+    onFileChange: vi.fn(),
+    openImportDialog: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useElectron', () => ({
+  isElectron: () => false,
+}));
+
+vi.mock('../store/previewWorkspace/persistence', () => ({
+  deleteWorkspace: vi.fn(),
+}));
+
+vi.mock('../store/workspaceStore', () => ({
+  useWorkspaceLabel: () => 'Test workspace',
+  useWorkspaceStore: (
+    selector: (state: {
+      capabilities: { canChangeWorkspace: boolean };
+      setCanvasCount: typeof setCanvasCount;
+      workspacePath: string;
+    }) => unknown,
+  ) =>
+    selector({
+      capabilities: { canChangeWorkspace: false },
+      setCanvasCount,
+      workspacePath: '/tmp/test-workspace',
+    }),
+}));
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+async function renderPage() {
+  const router = createMemoryRouter(
+    [
+      { path: '/spaces', element: <CanvasListPage /> },
+      {
+        path: '/canvas/:canvasId',
+        element: <div data-testid="canvas-route" />,
+      },
+    ],
+    { initialEntries: ['/spaces'] },
+  );
+
+  await act(async () => {
+    root.render(<RouterProvider router={router} />);
+  });
+
+  const link = container.querySelector<HTMLAnchorElement>(
+    'a[href="/canvas/space-1"]',
+  );
+  if (!link) throw new Error('Space card link was not rendered');
+  return { link, router };
+}
+
+describe('CanvasListPage navigation', () => {
+  it('renders each Space card as a link and uses in-tab routing for a plain click', async () => {
+    const { link, router } = await renderPage();
+
+    expect(link.textContent).toContain('Space One');
+    const event = new MouseEvent('click', {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+    });
+    await act(async () => {
+      link.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(router.state.location.pathname).toBe('/canvas/space-1');
+  });
+
+  it.each([
+    ['Ctrl-click', { ctrlKey: true, button: 0 }],
+    ['Cmd-click', { metaKey: true, button: 0 }],
+    ['middle-click', { button: 1 }],
+  ])('leaves %s to native browser link handling', async (_name, init) => {
+    const { link, router } = await renderPage();
+    const event = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      ...init,
+    });
+
+    await act(async () => {
+      link.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(router.state.location.pathname).toBe('/spaces');
+  });
+});

--- a/apps/web/src/pages/CanvasListPage.tsx
+++ b/apps/web/src/pages/CanvasListPage.tsx
@@ -4,7 +4,7 @@
 import { Download, Plus, Trash2, Upload } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { useNavigate, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import { listCanvases, exportCanvas, deleteCanvasById } from '../api/canvas';
 import { Button } from '../components/Common/Button';
@@ -37,7 +37,6 @@ export default function CanvasListPage() {
   const [isDeleting, setIsDeleting] = useState(false);
   const [exportingId, setExportingId] = useState<string | null>(null);
   const confirmDeleteButtonRef = useRef<HTMLButtonElement>(null);
-  const navigate = useNavigate();
   const {
     create: handleCreate,
     isCreating,
@@ -77,10 +76,6 @@ export default function CanvasListPage() {
     window.addEventListener('workspace-changed', handler);
     return () => window.removeEventListener('workspace-changed', handler);
   }, [fetchCanvases]);
-
-  const handleOpen = (canvasId: string) => {
-    navigate(`/canvas/${canvasId}`);
-  };
 
   const handleExport = async (canvasId: string) => {
     setExportingId(canvasId);
@@ -336,8 +331,8 @@ export default function CanvasListPage() {
                   key={canvas.canvasId}
                   className="group border-edge-default bg-surface hover:border-edge-default relative flex flex-col rounded-xl border p-5 text-left transition-all hover:shadow-md"
                 >
-                  <button
-                    onClick={() => handleOpen(canvas.canvasId)}
+                  <Link
+                    to={`/canvas/${canvas.canvasId}`}
                     className="flex flex-1 flex-col text-left"
                   >
                     <h3 className="text-fg-default group-hover:text-fg-default truncate text-sm font-semibold">
@@ -353,7 +348,7 @@ export default function CanvasListPage() {
                         date: formatDate(canvas.updatedAt),
                       })}
                     </div>
-                  </button>
+                  </Link>
                   {/* Export button */}
                   <Button
                     variant="ghost"

--- a/docs/architecture/web-architecture.md
+++ b/docs/architecture/web-architecture.md
@@ -121,6 +121,8 @@ The Markdown walk is what keeps images inside a `note` alive across Canvases —
 
 `/` is the workspace landing redirect. When the persisted World setting is enabled it redirects to the hidden World through `/canvas/:worldCanvasId`; otherwise it redirects to `/spaces`. The ordinary Space List remains a sibling page at `/spaces`, and every Canvas scope, including World, continues to use the existing `CanvasPage` and `/canvas/:canvasId` route.
 
+Primary navigation between the Space List and an ordinary Space uses React Router links rather than button-owned `navigate(...)` calls. An ordinary click therefore stays within the current tab and passes through the router's pending-save blocker, while Ctrl/Cmd-click, middle-click, keyboard activation, assistive-technology link discovery, and browser context-menu actions retain native anchor behavior. The Space Preview and legacy Portal interaction model is intentionally separate from this list-to-Space contract.
+
 The World setting defaults to disabled. Enabling it exposes the World navigation entry and changes subsequent workspace landing to World without deleting or resetting `.world`.
 
 `CanvasRefNode` renders a canonical Portal from persisted `targetCanvasId` plus one batched ordinary-Space title map loaded when World opens. Portal activation uses double-click, Enter while selected, or its Open action. A missing title after the Space list has loaded is rendered as an explicit broken reference; transient source titles are never persisted into World topology.


### PR DESCRIPTION
## Summary

- render Space list cards as native React Router links
- render the in-Space Back to Space list menu action as a link while preserving menu styling
- preserve browser Ctrl/Cmd-click, middle-click, context-menu, keyboard, and assistive-technology semantics
- document the navigation contract and add focused regression coverage

Space Preview and legacy Portal interactions intentionally remain unchanged for their planned dedicated redesign.

## Validation

- `pnpm typecheck`
- `pnpm format`
- `pnpm lint:fix`
- `pnpm --filter @huabu/web exec vitest run src/pages/CanvasListPage.test.tsx src/components/Panels/Header/AppMenu.test.tsx`

Closes #155